### PR TITLE
Add support for Hygon CSV3 feature

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+edk2 (2024.08-2deepin1) unstable; urgency=medium
+
+ * Add support for Hygon CSV3 feature:
+   - d/p/0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
+   - d/p/0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
+   - d/p/0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
+   - d/p/0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
+   - d/p/0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
+   - d/p/0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
+   - d/p/0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
+   - d/p/0011-OvmfPkg-Add-CsvDxe-driver.patch
+   - d/p/0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
+   - d/p/0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
+   - d/p/0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
+
+ -- hanliyang <hanliyang@hygon.cn>  Wed, 09 Oct 2024 21:26:28 +0000
+
 edk2 (2024.08-2) unstable; urgency=medium
 
   * qemu-efi-riscv64: Fix crash in KVM-based emulation (LP: #2036604):

--- a/debian/patches/0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
+++ b/debian/patches/0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
@@ -1,0 +1,137 @@
+From 0f4c760bcff4339b5ffe08b71dea78892b4b7134 Mon Sep 17 00:00:00 2001
+From: Xin Jiang <jiangxin@hygon.cn>
+Date: Thu, 11 Apr 2024 12:02:21 +0800
+Subject: [PATCH 04/14] MdePkg: Add StandardSignatureIsHygonGenuine() in
+ BaseCpuLib
+
+This function allows IA32/X64 code to determine if it is running on an
+Hygon brand processor.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ MdePkg/Include/Library/CpuLib.h           | 11 ++++++
+ MdePkg/Include/Register/Hygon/Cpuid.h     | 47 +++++++++++++++++++++++
+ MdePkg/Library/BaseCpuLib/X86BaseCpuLib.c | 24 ++++++++++++
+ 3 files changed, 82 insertions(+)
+ create mode 100644 MdePkg/Include/Register/Hygon/Cpuid.h
+
+diff --git a/MdePkg/Include/Library/CpuLib.h b/MdePkg/Include/Library/CpuLib.h
+index 27f3f82a..e987d6f2 100644
+--- a/MdePkg/Include/Library/CpuLib.h
++++ b/MdePkg/Include/Library/CpuLib.h
+@@ -74,6 +74,17 @@ StandardSignatureIsAuthenticAMD (
+   VOID
+   );
+ 
++/**
++  Determine if the standard CPU signature is "HygonGenuine".
++  @retval TRUE  The CPU signature matches.
++  @retval FALSE The CPU signature does not match.
++**/
++BOOLEAN
++EFIAPI
++StandardSignatureIsHygonGenuine (
++  VOID
++  );
++
+ /**
+   Return the 32bit CPU family and model value.
+   @return CPUID[01h].EAX with Processor Type and Stepping ID cleared.
+diff --git a/MdePkg/Include/Register/Hygon/Cpuid.h b/MdePkg/Include/Register/Hygon/Cpuid.h
+new file mode 100644
+index 00000000..e8a2c76b
+--- /dev/null
++++ b/MdePkg/Include/Register/Hygon/Cpuid.h
+@@ -0,0 +1,47 @@
++/** @file
++  CPUID leaf definitions.
++
++  Provides defines for CPUID leaf indexes.  Data structures are provided for
++  registers returned by a CPUID leaf that contain one or more bit fields.
++  If a register returned is a single 32-bit value, then a data structure is
++  not provided for that register.
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution. The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++**/
++
++#ifndef __HYGON_CPUID_H__
++#define __HYGON_CPUID_H__
++
++/**
++CPUID Signature Information
++
++@param   EAX  CPUID_SIGNATURE (0x00)
++
++@retval  EAX  Returns the highest value the CPUID instruction recognizes for
++              returning basic processor information. The value is returned is
++              processor specific.
++@retval  EBX  First 4 characters of a vendor identification string.
++@retval  ECX  Last 4 characters of a vendor identification string.
++@retval  EDX  Middle 4 characters of a vendor identification string.
++
++**/
++
++///
++/// @{ CPUID signature values returned by HYGON processors
++///
++#define CPUID_SIGNATURE_AUTHENTIC_HYGON_EBX  SIGNATURE_32 ('H', 'y', 'g', 'o')
++#define CPUID_SIGNATURE_AUTHENTIC_HYGON_EDX  SIGNATURE_32 ('n', 'G', 'e', 'n')
++#define CPUID_SIGNATURE_AUTHENTIC_HYGON_ECX  SIGNATURE_32 ('u', 'i', 'n', 'e')
++///
++/// @}
++///
++
++#endif
+diff --git a/MdePkg/Library/BaseCpuLib/X86BaseCpuLib.c b/MdePkg/Library/BaseCpuLib/X86BaseCpuLib.c
+index 1cad32a4..6d7ceb11 100644
+--- a/MdePkg/Library/BaseCpuLib/X86BaseCpuLib.c
++++ b/MdePkg/Library/BaseCpuLib/X86BaseCpuLib.c
+@@ -11,6 +11,7 @@
+ 
+ #include <Register/Intel/Cpuid.h>
+ #include <Register/Amd/Cpuid.h>
++#include <Register/Hygon/Cpuid.h>
+ 
+ #include <Library/BaseLib.h>
+ #include <Library/CpuLib.h>
+@@ -38,6 +39,29 @@ StandardSignatureIsAuthenticAMD (
+           RegEdx == CPUID_SIGNATURE_AUTHENTIC_AMD_EDX);
+ }
+ 
++/**
++  Determine if the standard CPU signature is "HygonGenuine".
++
++  @retval TRUE  The CPU signature matches.
++  @retval FALSE The CPU signature does not match.
++
++**/
++BOOLEAN
++EFIAPI
++StandardSignatureIsHygonGenuine (
++  VOID
++  )
++{
++  UINT32  RegEbx;
++  UINT32  RegEcx;
++  UINT32  RegEdx;
++
++  AsmCpuid (CPUID_SIGNATURE, NULL, &RegEbx, &RegEcx, &RegEdx);
++  return (RegEbx == CPUID_SIGNATURE_AUTHENTIC_HYGON_EBX &&
++          RegEcx == CPUID_SIGNATURE_AUTHENTIC_HYGON_ECX &&
++          RegEdx == CPUID_SIGNATURE_AUTHENTIC_HYGON_EDX);
++}
++
+ /**
+   Return the 32bit CPU family and model value.
+ 
+-- 
+2.25.1
+

--- a/debian/patches/0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
+++ b/debian/patches/0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
@@ -1,0 +1,82 @@
+From 8827f29e83fbaf26fd5cbc1def5dd8e9e7325ce2 Mon Sep 17 00:00:00 2001
+From: jiangxin <jiangxin@hygon.cn>
+Date: Sun, 10 Apr 2022 21:50:15 -0400
+Subject: [PATCH 05/14] UefiCpuPkg/LocalApicLib: Exclude second SendIpi
+ sequence on HYGON hardware
+
+On HYGON processors the second SendIpi in the SendInitSipiSipi and
+SendInitSipiSipiAllExcludingSelf routines is not required, and may cause
+undesired side-effects during MP initialization.
+
+This patch leverages the StandardSignatureIsHygonGenuine check to exclude
+the second SendIpi and its associated MicroSecondDelay (200).
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c             | 5 +++--
+ UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c b/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c
+index c4457d98..d816f03f 100644
+--- a/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c
++++ b/UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.c
+@@ -22,6 +22,7 @@
+ #include <Library/TimerLib.h>
+ #include <Library/PcdLib.h>
+ #include <Library/CpuLib.h>
++#include <Register/Hygon/Cpuid.h>
+ 
+ //
+ // Library internal functions
+@@ -555,7 +556,7 @@ SendInitSipiSipi (
+   IcrLow.Bits.DeliveryMode = LOCAL_APIC_DELIVERY_MODE_STARTUP;
+   IcrLow.Bits.Level        = 1;
+   SendIpi (IcrLow.Uint32, ApicId);
+-  if (!StandardSignatureIsAuthenticAMD ()) {
++  if (!StandardSignatureIsAuthenticAMD () && !StandardSignatureIsHygonGenuine ()) {
+     MicroSecondDelay (200);
+     SendIpi (IcrLow.Uint32, ApicId);
+   }
+@@ -581,7 +582,7 @@ SendInitSipiSipiAllExcludingSelf (
+   SendInitIpiAllExcludingSelf ();
+   MicroSecondDelay (PcdGet32 (PcdCpuInitIpiDelayInMicroSeconds));
+   SendStartupIpiAllExcludingSelf (StartupRoutine);
+-  if (!StandardSignatureIsAuthenticAMD ()) {
++  if (!StandardSignatureIsAuthenticAMD () && !StandardSignatureIsHygonGenuine ()) {
+     MicroSecondDelay (200);
+     SendStartupIpiAllExcludingSelf (StartupRoutine);
+   }
+diff --git a/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c b/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
+index 0560d38c..ea13cba4 100644
+--- a/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
++++ b/UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
+@@ -24,6 +24,7 @@
+ #include <Library/PcdLib.h>
+ #include <Library/CpuLib.h>
+ #include <IndustryStandard/Tdx.h>
++#include <Register/Hygon/Cpuid.h>
+ 
+ //
+ // Library internal functions
+@@ -794,7 +795,7 @@ SendInitSipiSipi (
+   IcrLow.Bits.DeliveryMode = LOCAL_APIC_DELIVERY_MODE_STARTUP;
+   IcrLow.Bits.Level        = 1;
+   SendIpi (IcrLow.Uint32, ApicId);
+-  if (!StandardSignatureIsAuthenticAMD ()) {
++  if (!StandardSignatureIsAuthenticAMD () && !StandardSignatureIsHygonGenuine ()) {
+     MicroSecondDelay (200);
+     SendIpi (IcrLow.Uint32, ApicId);
+   }
+@@ -820,7 +821,7 @@ SendInitSipiSipiAllExcludingSelf (
+   SendInitIpiAllExcludingSelf ();
+   MicroSecondDelay (PcdGet32 (PcdCpuInitIpiDelayInMicroSeconds));
+   SendStartupIpiAllExcludingSelf (StartupRoutine);
+-  if (!StandardSignatureIsAuthenticAMD ()) {
++  if (!StandardSignatureIsAuthenticAMD () && !StandardSignatureIsHygonGenuine ()) {
+     MicroSecondDelay (200);
+     SendStartupIpiAllExcludingSelf (StartupRoutine);
+   }
+-- 
+2.25.1
+

--- a/debian/patches/0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
+++ b/debian/patches/0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
@@ -1,0 +1,706 @@
+From 7979337bb3d9226f13f4bd2279f84ef3c981f765 Mon Sep 17 00:00:00 2001
+From: Liu Zixing <liuzixing@hygon.cn>
+Date: Fri, 25 Feb 2022 14:25:11 +0800
+Subject: [PATCH 06/14] OvmfPkg: Add CSV secure call library on Hygon CPU
+
+CSV is the secure virtualization feature on Hygon CPU.
+A CSV virtual machine is composed of private memory and shared memory.
+The private memory or shared memory can be converted to the other by
+the following steps:
+ - guest clear/set the c-bit in the guest page table
+ - guest send a update command to Hygon Secure Processor
+
+While the update command has to be forwarded by the VMM to the Secure
+Processor, to prevent  the malicious VMM from attacking the update
+command, a reliable command channel is required between the CSV VM
+and the Hygon Secure Processor.
+
+The secure call library is created to build a secure command channel
+between the VM and the Secure Processor by #NPF on a special private
+page which the VMM is not able to access.
+This special page is called secure call page.
+The VM puts command in the secure call page and triggers a #NPF
+to reach the Secure Processor.
+The Secure Processor then puts the response in the same page and
+finishes the #NPF.
+The information is protected in the secure call page all the way.
+
+CsvLib is added to implement the functionality and new PCDs are added
+accordingly.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/AmdSev/AmdSevX64.dsc                  |   1 +
+ OvmfPkg/AmdSev/AmdSevX64.fdf                  |   5 +-
+ OvmfPkg/Include/Library/CsvLib.h              |  84 +++++++
+ OvmfPkg/Library/CsvLib/CsvLib.c               |  85 +++++++
+ OvmfPkg/Library/CsvLib/CsvLib.inf             |  54 ++++
+ .../Library/CsvLib/Ia32/UpdateMemoryCsvLib.c  |  53 ++++
+ .../Library/CsvLib/X64/UpdateMemoryCsvLib.c   | 238 ++++++++++++++++++
+ OvmfPkg/OvmfPkg.dec                           |   8 +
+ OvmfPkg/OvmfPkgIa32.dsc                       |   2 +
+ OvmfPkg/OvmfPkgIa32X64.dsc                    |   2 +
+ OvmfPkg/OvmfPkgX64.dsc                        |   1 +
+ OvmfPkg/OvmfPkgX64.fdf                        |   5 +-
+ 12 files changed, 536 insertions(+), 2 deletions(-)
+ create mode 100644 OvmfPkg/Include/Library/CsvLib.h
+ create mode 100644 OvmfPkg/Library/CsvLib/CsvLib.c
+ create mode 100644 OvmfPkg/Library/CsvLib/CsvLib.inf
+ create mode 100644 OvmfPkg/Library/CsvLib/Ia32/UpdateMemoryCsvLib.c
+ create mode 100644 OvmfPkg/Library/CsvLib/X64/UpdateMemoryCsvLib.c
+
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.dsc b/OvmfPkg/AmdSev/AmdSevX64.dsc
+index 40553c00..3eb494b3 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
++++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
+@@ -173,6 +173,7 @@
+   PeiHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/PeiHardwareInfoLib.inf
+   DxeHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
+   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
++  CsvLib|OvmfPkg/Library/CsvLib/CsvLib.inf
+ 
+ !if $(SOURCE_DEBUG_ENABLE) == TRUE
+   PeCoffExtraActionLib|SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLibDebug.inf
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.fdf b/OvmfPkg/AmdSev/AmdSevX64.fdf
+index 70e6434b..a544f80f 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.fdf
++++ b/OvmfPkg/AmdSev/AmdSevX64.fdf
+@@ -80,7 +80,10 @@ gUefiOvmfPkgTokenSpaceGuid.PcdQemuHashTableBase|gUefiOvmfPkgTokenSpaceGuid.PcdQe
+ 0x011000|0x001000
+ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableSize
+ 
+-0x012000|0x00E000
++0x012000|0x002000
++gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase|gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
++
++0x014000|0x00C000
+ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
+ 
+ 0x020000|0x0E0000
+diff --git a/OvmfPkg/Include/Library/CsvLib.h b/OvmfPkg/Include/Library/CsvLib.h
+new file mode 100644
+index 00000000..ceeab7dc
+--- /dev/null
++++ b/OvmfPkg/Include/Library/CsvLib.h
+@@ -0,0 +1,84 @@
++/** @file
++
++  CSV base library helper function
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#ifndef _CSV_LIB_H_
++#define _CSV_LIB_H_
++
++#include <Base.h>
++
++typedef struct {
++  IN UINT64         BaseAddress;
++  IN UINT64         Size;
++} CSV_SECURE_CMD_SHARED_REGION;
++
++typedef enum {
++  CsvSecureCmdEnc     = 1,
++  CsvSecureCmdDec,
++  CsvSecureCmdReset,
++  CsvSecureCmdUpdateSecureCallTable,
++  CsvSecureCmdMapLowerMemory,  //secure memory range below 4G
++  CsvSecureCmdMapUpperMemory   //secure memory range above 4G
++} CSV_SECURE_COMMAND_TYPE;
++
++/**
++  Returns a boolean to indicate whether CSV is enabled
++
++  @retval TRUE           CSV is enabled
++  @retval FALSE          CSV is not enabled
++**/
++BOOLEAN
++EFIAPI
++CsvIsEnabled (
++  VOID
++  );
++
++#define CSV_SHARED_MEMORY_SIGNATURE   SIGNATURE_32('C','S','V',' ')
++
++typedef struct {
++  UINTN           Signature;
++  LIST_ENTRY      Link;
++  UINT64          Start;
++  UINT64          Length;
++} CsvSharedMemoryEntry;
++
++VOID
++EFIAPI
++CsvUpdateMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages,
++  IN BOOLEAN                  Dec
++);
++
++VOID
++EFIAPI
++CsvResetMemory (
++  VOID
++);
++
++VOID
++EFIAPI
++CsvUpdateMapLowerMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++);
++
++VOID
++EFIAPI
++CsvUpdateMapUpperMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++);
++#endif // _CSV_LIB_H_
+diff --git a/OvmfPkg/Library/CsvLib/CsvLib.c b/OvmfPkg/Library/CsvLib/CsvLib.c
+new file mode 100644
+index 00000000..80cd4a50
+--- /dev/null
++++ b/OvmfPkg/Library/CsvLib/CsvLib.c
+@@ -0,0 +1,85 @@
++/** @file
++
++  CSV library helper function
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Library/BaseLib.h>
++#include <Uefi/UefiBaseType.h>
++#include <Library/CsvLib.h>
++#include <Library/DebugLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Register/Cpuid.h>
++#include <Register/Amd/Cpuid.h>
++#include <Register/Hygon/Cpuid.h>
++#include <Library/MemEncryptSevLib.h>
++#include <Library/CpuLib.h>
++#include <Register/Amd/SevSnpMsr.h>
++
++STATIC BOOLEAN mCsvStatus = FALSE;
++STATIC BOOLEAN mCsvStatusChecked = FALSE;
++
++/**
++
++  Reads and sets the status of CSV features
++  **/
++STATIC
++VOID
++EFIAPI
++InternalCsvStatus (
++  VOID
++  )
++{
++  UINT32                            RegEax;
++
++  //
++  // Check if memory encryption leaf exist
++  //
++  AsmCpuid (CPUID_EXTENDED_FUNCTION, &RegEax, NULL, NULL, NULL);
++  if (RegEax >= CPUID_MEMORY_ENCRYPTION_INFO) {
++    if(StandardSignatureIsHygonGenuine ()){
++      //
++      // Check MSR_0xC0010131 Bit 30 (Csv Enabled)
++      //
++      MSR_SEV_STATUS_REGISTER           Msr;
++      Msr.Uint32 = AsmReadMsr32 (MSR_SEV_STATUS);
++      if (Msr.Uint32 & (1 << 30)) {
++        mCsvStatus = TRUE;
++        DEBUG ((EFI_D_INFO, "CSV is enabled\n"));
++      }
++    }
++  }
++  mCsvStatusChecked = TRUE;
++}
++
++/**
++  Returns a boolean to indicate whether CSV is enabled
++
++  @retval TRUE           CSV is enabled
++  @retval FALSE          CSV is not enabled
++**/
++BOOLEAN
++EFIAPI
++CsvIsEnabled (
++  VOID
++  )
++{
++  if (!MemEncryptSevEsIsEnabled ())
++    return FALSE;
++
++  if (!mCsvStatusChecked) {
++    InternalCsvStatus ();
++  }
++
++  return mCsvStatus;
++}
+diff --git a/OvmfPkg/Library/CsvLib/CsvLib.inf b/OvmfPkg/Library/CsvLib/CsvLib.inf
+new file mode 100644
+index 00000000..57efbe70
+--- /dev/null
++++ b/OvmfPkg/Library/CsvLib/CsvLib.inf
+@@ -0,0 +1,54 @@
++## @file
++#  Library provides the helper functions for CSV guest
++#
++# Copyright (c) 2022 HYGON. All rights reserved.<BR>
++#
++#  This program and the accompanying materials
++#  are licensed and made available under the terms and conditions of the BSD
++#  License which accompanies this distribution. The full text of the license
++#  may be found at http://opensource.org/licenses/bsd-license.php
++#
++#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR
++#  IMPLIED.
++#
++#
++##
++
++[Defines]
++  INF_VERSION                    = 1.25
++  BASE_NAME                      = CsvLib
++  FILE_GUID                      = 9460ef3a-b9c3-11e9-8324-7371ac35e1e3
++  MODULE_TYPE                    = BASE
++  VERSION_STRING                 = 1.0
++  LIBRARY_CLASS                  = CsvLib|PEIM DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_DRIVER
++
++#
++# The following information is for reference only and not required by the build
++# tools.
++#
++# VALID_ARCHITECTURES           = Ia32 X64
++#
++
++[Packages]
++  MdePkg/MdePkg.dec
++  OvmfPkg/OvmfPkg.dec
++  UefiCpuPkg/UefiCpuPkg.dec
++
++[Sources]
++  CsvLib.c
++
++[Sources.X64]
++  X64/UpdateMemoryCsvLib.c
++[Sources.IA32]
++  Ia32/UpdateMemoryCsvLib.c
++
++[LibraryClasses]
++  BaseLib
++  CpuLib
++  DebugLib
++  MemEncryptSevLib
++
++[Pcd]
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
+diff --git a/OvmfPkg/Library/CsvLib/Ia32/UpdateMemoryCsvLib.c b/OvmfPkg/Library/CsvLib/Ia32/UpdateMemoryCsvLib.c
+new file mode 100644
+index 00000000..15d3aa89
+--- /dev/null
++++ b/OvmfPkg/Library/CsvLib/Ia32/UpdateMemoryCsvLib.c
+@@ -0,0 +1,53 @@
++/** @file
++
++  CSV library helper function
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Library/CsvLib.h>
++
++VOID
++EFIAPI
++CsvUpdateMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages,
++  IN BOOLEAN                  Dec
++)
++{
++}
++
++VOID
++EFIAPI
++CsvResetMemory (
++  VOID
++)
++{
++}
++
++VOID
++EFIAPI
++CsvUpdateMapLowerMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++)
++{
++}
++
++VOID
++EFIAPI
++CsvUpdateMapUpperMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++)
++{
++}
+diff --git a/OvmfPkg/Library/CsvLib/X64/UpdateMemoryCsvLib.c b/OvmfPkg/Library/CsvLib/X64/UpdateMemoryCsvLib.c
+new file mode 100644
+index 00000000..13d06d7c
+--- /dev/null
++++ b/OvmfPkg/Library/CsvLib/X64/UpdateMemoryCsvLib.c
+@@ -0,0 +1,238 @@
++/** @file
++
++  CSV library helper function
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Library/BaseLib.h>
++#include <Uefi/UefiBaseType.h>
++#include <Library/CsvLib.h>
++#include <Library/DebugLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/IoLib.h>
++
++#define SECURE_CALL_ENTRY_MAX    (254)
++
++
++typedef struct {
++  union {
++      UINT8                Guid[16];
++      UINT64               Guid64[2];
++  };
++  UINT32                   CmdType;
++  UINT32                   Nums;
++  UINT64                   Unused;
++  struct {
++      UINT64               BaseAddress;
++      UINT64               Size;
++  } Entry[SECURE_CALL_ENTRY_MAX];
++} CSV_SECURE_CALL_CMD;
++
++STATIC UINT32 SecureCallPageIdx = 0;
++
++STATIC  UINTN MemorySizeBelow4G = (UINTN)-1;
++STATIC  UINTN MemorySizeAbove4G = (UINTN)-1;
++
++STATIC
++VOID
++EFIAPI
++CsvSecureCall(
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages,
++  IN CSV_SECURE_COMMAND_TYPE  CmdType
++)
++{
++  volatile CSV_SECURE_COMMAND_TYPE CmdAck = 0;
++
++  CSV_SECURE_CALL_CMD *SecureCallPageRead;
++  CSV_SECURE_CALL_CMD *SecureCallPageWrite;
++  UINTN  SecureCallBase = 0;
++
++  if (CsvIsEnabled () == FALSE) {
++    return ;
++  }
++
++  SecureCallBase = FixedPcdGet32 (PcdCsvDefaultSecureCallBase);
++
++  SecureCallPageRead =
++    (CSV_SECURE_CALL_CMD *)(UINT64)
++    (EFI_PAGE_SIZE * SecureCallPageIdx + SecureCallBase);
++
++  SecureCallPageWrite =
++    (CSV_SECURE_CALL_CMD *)
++    (UINT64)(EFI_PAGE_SIZE * (1 - SecureCallPageIdx) + SecureCallBase);
++
++  while(1) {
++    SecureCallPageWrite->CmdType = (UINT32)CmdType;
++    SecureCallPageWrite->Nums = 1;
++    SecureCallPageWrite->Entry[0].BaseAddress = (UINT64)BaseAddress;
++    SecureCallPageWrite->Entry[0].Size = (UINT64)NumPages << EFI_PAGE_SHIFT;
++
++    MemoryFence ();
++
++    CmdAck = SecureCallPageRead->CmdType;
++    if (CmdAck != CmdType)
++      break;
++  }
++  SecureCallPageIdx = 1 - SecureCallPageIdx;
++}
++
++STATIC
++UINT8
++CmosRead8 (
++  IN      UINTN                     Index
++  )
++{
++  IoWrite8 (0x70, (UINT8) Index);
++  return IoRead8 (0x71);
++}
++
++
++STATIC
++VOID
++EFIAPI
++CsvGetSystemMemory(
++  VOID
++  )
++{
++  UINT8 Cmos0x34;
++  UINT8 Cmos0x35;
++  UINT32 Size;
++  UINTN  CmosIndex;
++
++  //
++  // system memory below 4GB MB
++  //
++
++  Cmos0x34 = (UINT8) CmosRead8 (0x34);
++  Cmos0x35 = (UINT8) CmosRead8 (0x35);
++
++  MemorySizeBelow4G =
++    (UINT32) (((UINTN)((Cmos0x35 << 8) + Cmos0x34) << 16) + SIZE_16MB);
++
++  //
++  // system memory above 4GB MB
++  //
++
++  Size = 0;
++  for (CmosIndex = 0x5d; CmosIndex >= 0x5b; CmosIndex--) {
++    Size = (UINT32) (Size << 8) + (UINT32) CmosRead8 (CmosIndex);
++  }
++
++  MemorySizeAbove4G = LShiftU64 (Size, 16);
++}
++
++STATIC
++BOOLEAN
++EFIAPI
++CsvIsDRAM(
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++  )
++{
++  UINTN             Size = EFI_PAGES_TO_SIZE (NumPages);
++  PHYSICAL_ADDRESS  EndAddress;
++
++  Size = EFI_PAGES_TO_SIZE (NumPages);
++  EndAddress = BaseAddress + Size;
++
++  if (MemorySizeBelow4G == (UINTN)-1 ||
++      MemorySizeAbove4G == (UINTN)-1) {
++    CsvGetSystemMemory ();
++  }
++
++  if (BaseAddress < MemorySizeBelow4G) {
++    return TRUE;
++  } else if (BaseAddress >= BASE_4GB &&
++             BaseAddress < (BASE_4GB + MemorySizeAbove4G)) {
++    return TRUE;
++  } else if (EndAddress > BASE_4GB &&
++             EndAddress <= (BASE_4GB + MemorySizeAbove4G)) {
++    return TRUE;
++  } else {
++    return FALSE;
++  }
++}
++
++STATIC
++VOID
++EFIAPI
++CsvUpdateEncryptMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++)
++{
++  PHYSICAL_ADDRESS PageAddress = BaseAddress & ~EFI_PAGE_MASK;
++
++  if (CsvIsDRAM (PageAddress, NumPages)) {
++    CsvSecureCall (PageAddress, NumPages, CsvSecureCmdEnc);
++  }
++}
++
++STATIC
++VOID
++EFIAPI
++CsvUpdateDecryptMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++)
++{
++  PHYSICAL_ADDRESS PageAddress = BaseAddress & ~EFI_PAGE_MASK;
++
++  if (CsvIsDRAM (PageAddress, NumPages)) {
++    CsvSecureCall (PageAddress, NumPages, CsvSecureCmdDec);
++  }
++}
++
++VOID
++EFIAPI
++CsvUpdateMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages,
++  IN BOOLEAN                  Dec
++  )
++{
++  if (Dec)
++    CsvUpdateDecryptMemory (BaseAddress, NumPages);
++  else
++    CsvUpdateEncryptMemory (BaseAddress, NumPages);
++}
++
++VOID
++EFIAPI
++CsvResetMemory (
++  VOID
++)
++{
++  CsvSecureCall (0, 0, CsvSecureCmdReset);
++}
++
++VOID
++EFIAPI
++CsvUpdateMapLowerMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++)
++{
++  CsvSecureCall (BaseAddress, NumPages, CsvSecureCmdMapLowerMemory);
++}
++
++VOID
++EFIAPI
++CsvUpdateMapUpperMemory (
++  IN PHYSICAL_ADDRESS         BaseAddress,
++  IN UINTN                    NumPages
++)
++{
++  CsvSecureCall (BaseAddress, NumPages, CsvSecureCmdMapUpperMemory);
++}
+diff --git a/OvmfPkg/OvmfPkg.dec b/OvmfPkg/OvmfPkg.dec
+index c1c81980..dec85152 100644
+--- a/OvmfPkg/OvmfPkg.dec
++++ b/OvmfPkg/OvmfPkg.dec
+@@ -152,6 +152,10 @@
+   #
+   CpuMmuInitLib|Include/Library/CpuMmuInitLib.h
+ 
++  ##  @libraryclass  CSV Library
++  #
++  CsvLib|Include/Library/CsvLib.h
++
+ [Guids]
+   gUefiOvmfPkgTokenSpaceGuid            = {0x93bb96af, 0xb9f2, 0x4eb8, {0x94, 0x62, 0xe0, 0xba, 0x74, 0x56, 0x42, 0x36}}
+   gEfiXenInfoGuid                       = {0xd3b46f3b, 0xd441, 0x1244, {0x9a, 0x12, 0x0, 0x12, 0x27, 0x3f, 0xc1, 0x4d}}
+@@ -353,6 +357,10 @@
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaBase|0|UINT32|0x70
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaSize|0|UINT32|0x71
+ 
++  ## the base address of the secure call pages used by CSV.
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase|0|UINT32|0x76
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize|0|UINT32|0x77
++
+ [PcdsDynamic, PcdsDynamicEx]
+   gUefiOvmfPkgTokenSpaceGuid.PcdEmuVariableEvent|0|UINT64|2
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable|FALSE|BOOLEAN|0x10
+diff --git a/OvmfPkg/OvmfPkgIa32.dsc b/OvmfPkg/OvmfPkgIa32.dsc
+index bd6e8abb..c8cba60a 100644
+--- a/OvmfPkg/OvmfPkgIa32.dsc
++++ b/OvmfPkg/OvmfPkgIa32.dsc
+@@ -190,6 +190,8 @@
+   DxeHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
+   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+   HstiLib|MdePkg/Library/DxeHstiLib/DxeHstiLib.inf
++  CsvLib|OvmfPkg/Library/CsvLib/CsvLib.inf
++
+ !if $(SMM_REQUIRE) == FALSE
+   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf
+ !endif
+diff --git a/OvmfPkg/OvmfPkgIa32X64.dsc b/OvmfPkg/OvmfPkgIa32X64.dsc
+index f28049a3..9e9a22a0 100644
+--- a/OvmfPkg/OvmfPkgIa32X64.dsc
++++ b/OvmfPkg/OvmfPkgIa32X64.dsc
+@@ -195,6 +195,8 @@
+   DxeHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
+   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+   HstiLib|MdePkg/Library/DxeHstiLib/DxeHstiLib.inf
++  CsvLib|OvmfPkg/Library/CsvLib/CsvLib.inf
++
+ !if $(SMM_REQUIRE) == FALSE
+   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf
+ !endif
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index efb0eedb..c428bdd0 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -207,6 +207,7 @@
+   DxeHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
+   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+   HstiLib|MdePkg/Library/DxeHstiLib/DxeHstiLib.inf
++  CsvLib|OvmfPkg/Library/CsvLib/CsvLib.inf
+ 
+ !if $(SMM_REQUIRE) == FALSE
+   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf
+diff --git a/OvmfPkg/OvmfPkgX64.fdf b/OvmfPkg/OvmfPkgX64.fdf
+index b6497058..0409e513 100644
+--- a/OvmfPkg/OvmfPkgX64.fdf
++++ b/OvmfPkg/OvmfPkgX64.fdf
+@@ -100,7 +100,10 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecSvsmCaaBase|gUefiOvmfPkgTokenSpaceGuid.PcdO
+ 0x010000|0x001000
+ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableSize
+ 
+-0x011000|0x00F000
++0x011000|0x002000
++gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase|gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
++
++0x013000|0x00D000
+ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
+ 
+ 0x020000|0x0E0000
+-- 
+2.25.1
+

--- a/debian/patches/0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
+++ b/debian/patches/0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
@@ -1,0 +1,219 @@
+From f2ea470f39234c0c1b09fe0db4781f04f7a4d3cd Mon Sep 17 00:00:00 2001
+From: Liu Zixing <liuzixing@hygon.cn>
+Date: Fri, 25 Feb 2022 15:55:44 +0800
+Subject: [PATCH 07/14] OvmfPkg/ResetVector: Support CSV in ResetVector phase
+
+- A GUID is written along with the first secure call page address,
+by which the Secure Processor can locate the first secure call page
+address.
+
+- Check whether the VM is a CSV VM when setting the first page table
+
+- CSV VM will update first shared GHCB page address to Secure Processor
+by secure call page
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/ResetVector/Ia16/ResetVectorVtf0.asm |  15 +++
+ OvmfPkg/ResetVector/Ia32/AmdSev.asm          |   9 ++
+ OvmfPkg/ResetVector/Ia32/CsvInit.asm         | 107 +++++++++++++++++++
+ OvmfPkg/ResetVector/ResetVector.inf          |   2 +
+ OvmfPkg/ResetVector/ResetVector.nasmb        |   4 +
+ 5 files changed, 137 insertions(+)
+ create mode 100644 OvmfPkg/ResetVector/Ia32/CsvInit.asm
+
+diff --git a/OvmfPkg/ResetVector/Ia16/ResetVectorVtf0.asm b/OvmfPkg/ResetVector/Ia16/ResetVectorVtf0.asm
+index 8f94da89..49a84a5e 100644
+--- a/OvmfPkg/ResetVector/Ia16/ResetVectorVtf0.asm
++++ b/OvmfPkg/ResetVector/Ia16/ResetVectorVtf0.asm
+@@ -48,6 +48,21 @@ TIMES (15 - ((guidedStructureEnd - guidedStructureStart + 15) % 16)) DB 0
+ guidedStructureStart:
+ 
+ %ifdef ARCH_X64
++;
++; CSV secure call table
++;
++; Provide secure call pages when boot up for CSV guest.
++;
++; GUID : 9a5d926f-2fa5-ceba-ab21-6b275d5556a5
++;
++csvSecureCallBase:
++    DD      CSV_DEFAULT_SECURE_CALL_SIZE
++    DD      CSV_DEFAULT_SECURE_CALL_BASE
++    DW      csvSecureCallEnd - csvSecureCallBase
++    DB      0x6F, 0x92, 0x5D, 0x9A, 0xA5, 0x2F, 0xBA, 0xCE
++    DB      0xAB, 0x21, 0x6B, 0x27, 0x5D, 0x55, 0x56, 0xA5
++csvSecureCallEnd:
++
+ ;
+ ; TDX Metadata offset block
+ ;
+diff --git a/OvmfPkg/ResetVector/Ia32/AmdSev.asm b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+index 827c8743..7f942178 100644
+--- a/OvmfPkg/ResetVector/Ia32/AmdSev.asm
++++ b/OvmfPkg/ResetVector/Ia32/AmdSev.asm
+@@ -191,6 +191,15 @@ pageTableEntries4kLoop:
+     mov     ecx, (GHCB_BASE & 0x1F_FFFF) >> 12
+     mov     [ecx * 8 + GHCB_PT_ADDR + 4], strict dword 0
+ 
++    OneTimeCall   CheckCsvFeature
++    test    eax, eax
++    jz      SevClearPageEncMaskForGhcbPageExit
++
++    OneTimeCall   CsvInit
++    mov     eax,  1
++    test    ecx,  ecx
++    jz      SevEsUnexpectedRespTerminate
++
+ SevClearPageEncMaskForGhcbPageExit:
+     OneTimeCallRet SevClearPageEncMaskForGhcbPage
+ 
+diff --git a/OvmfPkg/ResetVector/Ia32/CsvInit.asm b/OvmfPkg/ResetVector/Ia32/CsvInit.asm
+new file mode 100644
+index 00000000..0744a35e
+--- /dev/null
++++ b/OvmfPkg/ResetVector/Ia32/CsvInit.asm
+@@ -0,0 +1,107 @@
++;------------------------------------------------------------------------------
++; @file
++; Provide the functions to check whether CSV is enabled.
++;
++; Copyright (c) 2022, HYGON. All rights reserved.<BR>
++; SPDX-License-Identifier: BSD-2-Clause-Patent
++;
++;------------------------------------------------------------------------------
++
++BITS    32
++
++; If Secure Command returns ok then ECX will be non-zero.
++; If Secure Command returns error then ECX will be zero.
++CsvInit:
++    mov       esp, SEV_ES_VC_TOP_OF_STACK
++    push      esi
++    push      edi
++
++    ; copy SECURE_CALL_GUID to CSV_DEFAULT_SECURE_CALL_BASE + 4096
++    cld
++    mov       esi, ADDR_OF(SECURE_CALL_GUID)
++    mov       edi, CSV_DEFAULT_SECURE_CALL_BASE
++    add       edi, 4096
++    mov       ecx, 4
++    rep       movsd
++
++    ; secure call begin
++    mov       esi, CSV_DEFAULT_SECURE_CALL_BASE
++    ; write secure cmd to page B
++    ; 16 bytes of page A/B is GUID, just ignore
++    mov       [esi + 4096 + 16], DWORD 2        ; dec command
++    mov       [esi + 4096 + 20], DWORD 1        ; 1 entry
++    ; 8 bytes is unused
++    mov       [esi + 4096 + 32], DWORD GHCB_BASE; lower address
++    mov       [esi + 4096 + 36], DWORD 0        ; upper address
++    mov       [esi + 4096 + 40], DWORD 4096     ; lower 32 bit of page size
++    mov       [esi + 4096 + 44], DWORD 0        ; upper 32 bit of page size
++    mfence
++    ; read from page A
++    mov       ecx, [esi + 16]
++    ; check if the response comes
++    cmp       ecx, 2
++    jne       SecureCommandDone
++    ; no secure command response, clean ecx
++    xor       ecx, ecx
++    ; secure call end
++
++SecureCommandDone:
++    pop       edi
++    pop       esi
++    mov       esp, 0
++
++    OneTimeCallRet CsvInit
++
++; Check if CSV feature is enabled.
++;
++; Modified:  EAX, EBX, ECX, EDX
++;
++; If CSV is enabled then EAX will be non-zero.
++; If CSV is disabled then EAX will be zero.
++;
++CheckCsvFeature:
++    mov       esp, SEV_ES_VC_TOP_OF_STACK
++    mov       eax, ADDR_OF(Idtr)
++    lidt      [cs:eax]
++
++    ; Check if vendor Hygon CPUID_SIGNATURE(0x0)
++    ;   CPUID raises a #VC exception if running as an SEV-ES guest
++    mov       eax, 0
++    cpuid
++
++    cmp       ebx, 0x6f677948
++    jne       NoCsv
++    cmp       ecx, 0x656e6975
++    jne       NoCsv
++    cmp       edx, 0x6e65476e
++    jne       NoCsv
++
++    ; Check if CSV is enabled
++    ;  MSR_0xC0010131 - Bit 30 (CSV enabled)
++    mov       ecx, 0xc0010131
++    rdmsr
++    and       eax, 0x40000000
++    jmp       CsvExit
++
++NoCsv:
++    xor       eax, eax
++
++CsvExit:
++    ;
++    ; Clear exception handlers and stack
++    ;
++    push      eax
++    mov       eax, ADDR_OF(IdtrClear)
++    lidt      [cs:eax]
++    pop       eax
++    mov       esp, 0
++
++    OneTimeCallRet CheckCsvFeature
++
++SECURE_CALL_GUID:
++;    low      0xceba2fa59a5d926f
++;    high     0xa556555d276b21ab
++     dd       0x9a5d926f
++     dd       0xceba2fa5
++     dd       0x276b21ab
++     dd       0xa556555d
+diff --git a/OvmfPkg/ResetVector/ResetVector.inf b/OvmfPkg/ResetVector/ResetVector.inf
+index 7bd517e6..cdb5f277 100644
+--- a/OvmfPkg/ResetVector/ResetVector.inf
++++ b/OvmfPkg/ResetVector/ResetVector.inf
+@@ -35,6 +35,8 @@
+ 
+ [Pcd]
+   gUefiCpuPkgTokenSpaceGuid.PcdSevEsWorkAreaBase
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecGhcbBase
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecGhcbSize
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecGhcbPageTableBase
+diff --git a/OvmfPkg/ResetVector/ResetVector.nasmb b/OvmfPkg/ResetVector/ResetVector.nasmb
+index 7279ac64..acaae4f6 100644
+--- a/OvmfPkg/ResetVector/ResetVector.nasmb
++++ b/OvmfPkg/ResetVector/ResetVector.nasmb
+@@ -139,11 +139,15 @@
+   %define TDX_WORK_AREA_PGTBL_READY (FixedPcdGet32 (PcdOvmfWorkAreaBase) + 4)
+   %define TDX_WORK_AREA_GPAW        (FixedPcdGet32 (PcdOvmfWorkAreaBase) + 8)
+ 
++  %define CSV_DEFAULT_SECURE_CALL_BASE FixedPcdGet32 (PcdCsvDefaultSecureCallBase)
++  %define CSV_DEFAULT_SECURE_CALL_SIZE FixedPcdGet32 (PcdCsvDefaultSecureCallSize)
++
+   %include "X64/IntelTdxMetadata.asm"
+   %include "Ia32/Flat32ToFlat64.asm"
+   %include "Ia32/PageTables64.asm"
+   %include "Ia32/IntelTdx.asm"
+   %include "X64/OvmfSevMetadata.asm"
++  %include "Ia32/CsvInit.asm"
+ %endif
+ 
+ %include "Ia32/AmdSev.asm"
+-- 
+2.25.1
+

--- a/debian/patches/0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
+++ b/debian/patches/0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
@@ -1,0 +1,214 @@
+From 0ad107b4fdf058d9fcf9fc051342eee476c9aea8 Mon Sep 17 00:00:00 2001
+From: Liu Zixing <liuzixing@hygon.cn>
+Date: Fri, 25 Feb 2022 16:12:38 +0800
+Subject: [PATCH 08/14] OvmfPkg/PlatformPei: Initialize CSV VM's memory
+
+For CSV VM, the Secure Processor builds a temporary nested
+page table to help the guest to run into the PEI phase.
+
+In PEI phase, CSV VM detects the start address and size of the
+guest physical memory.
+
+The CSV VM sends the memory information to the Secure Processor
+to build the permanent nested page table.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/Include/Library/PlatformInitLib.h   |  5 ++
+ OvmfPkg/Library/PlatformInitLib/MemDetect.c |  2 +-
+ OvmfPkg/PlatformPei/Csv.c                   | 82 +++++++++++++++++++++
+ OvmfPkg/PlatformPei/Platform.c              |  2 +
+ OvmfPkg/PlatformPei/Platform.h              | 10 +++
+ OvmfPkg/PlatformPei/PlatformPei.inf         |  4 +
+ 6 files changed, 104 insertions(+), 1 deletion(-)
+ create mode 100644 OvmfPkg/PlatformPei/Csv.c
+
+diff --git a/OvmfPkg/Include/Library/PlatformInitLib.h b/OvmfPkg/Include/Library/PlatformInitLib.h
+index 57b18b94..6c28c7fb 100644
+--- a/OvmfPkg/Include/Library/PlatformInitLib.h
++++ b/OvmfPkg/Include/Library/PlatformInitLib.h
+@@ -151,6 +151,11 @@ PlatformGetSystemMemorySizeBelow4gb (
+   IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
+   );
+ 
++UINT64
++EFIAPI
++PlatformGetSystemMemorySizeAbove4gb (
++  );
++
+ /**
+   Initialize the PhysMemAddressWidth field in PlatformInfoHob based on guest RAM size.
+ **/
+diff --git a/OvmfPkg/Library/PlatformInitLib/MemDetect.c b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+index bd6c79e4..fa6cce7e 100644
+--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
++++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+@@ -440,8 +440,8 @@ PlatformGetSystemMemorySizeBelow4gb (
+   PlatformInfoHob->LowMemory = (UINT32)(((UINTN)((Cmos0x35 << 8) + Cmos0x34) << 16) + SIZE_16MB);
+ }
+ 
+-STATIC
+ UINT64
++EFIAPI
+ PlatformGetSystemMemorySizeAbove4gb (
+   )
+ {
+diff --git a/OvmfPkg/PlatformPei/Csv.c b/OvmfPkg/PlatformPei/Csv.c
+new file mode 100644
+index 00000000..5ab83312
+--- /dev/null
++++ b/OvmfPkg/PlatformPei/Csv.c
+@@ -0,0 +1,82 @@
++/** @file
++
++  CSV initialization in PEI
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Library/BaseLib.h>
++#include <Uefi/UefiBaseType.h>
++#include <Library/DebugLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/HobLib.h>
++#include <Library/CsvLib.h>
++#include <Library/MemEncryptSevLib.h>
++#include <Library/PlatformInitLib.h>
++
++#include "Platform.h"
++
++VOID
++CsvInitializeMemInfo (
++  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
++  )
++{
++  UINT64                      LowerMemorySize;
++  UINT64                      UpperMemorySize;
++
++  if (!CsvIsEnabled ()) {
++    return ;
++  }
++
++  LowerMemorySize = PlatformInfoHob->LowMemory;
++  UpperMemorySize = PlatformGetSystemMemorySizeAbove4gb ();
++
++  CsvUpdateMapLowerMemory (
++    0,
++    LowerMemorySize >> EFI_PAGE_SHIFT
++    );
++
++  if (UpperMemorySize > 0) {
++    CsvUpdateMapUpperMemory (
++      BASE_4GB,
++      UpperMemorySize >> EFI_PAGE_SHIFT
++      );
++  }
++
++  BuildMemoryAllocationHob (
++    (EFI_PHYSICAL_ADDRESS)(UINTN) FixedPcdGet32 (PcdCsvDefaultSecureCallBase),
++    (UINT64)(UINTN) FixedPcdGet32 (PcdCsvDefaultSecureCallSize),
++    EfiReservedMemoryType
++    );
++}
++
++VOID
++CsvInitializeGhcb (
++  VOID
++  )
++{
++  RETURN_STATUS        EncryptStatus;
++
++  if (!CsvIsEnabled ()) {
++    return ;
++  }
++
++  //
++  // Encrypt the SecGhcb as it's not a Ghcb any more
++  //
++  EncryptStatus = MemEncryptSevSetPageEncMask(
++                    0,
++                    PcdGet32 (PcdOvmfSecGhcbBase),
++                    1
++                    );
++  ASSERT_RETURN_ERROR (EncryptStatus);
++}
+diff --git a/OvmfPkg/PlatformPei/Platform.c b/OvmfPkg/PlatformPei/Platform.c
+index 01145297..2a4ce641 100644
+--- a/OvmfPkg/PlatformPei/Platform.c
++++ b/OvmfPkg/PlatformPei/Platform.c
+@@ -346,6 +346,7 @@ InitializePlatform (
+   PlatformQemuUc32BaseInitialization (PlatformInfoHob);
+ 
+   InitializeRamRegions (PlatformInfoHob);
++  CsvInitializeMemInfo (PlatformInfoHob);
+ 
+   if (PlatformInfoHob->BootMode != BOOT_ON_S3_RESUME) {
+     if (!PlatformInfoHob->SmmSmramRequire) {
+@@ -366,6 +367,7 @@ InitializePlatform (
+     MiscInitialization (PlatformInfoHob);
+     PlatformIdInitialization (PeiServices);
+   }
++  CsvInitializeGhcb();
+ 
+   IntelTdxInitialize ();
+   InstallFeatureControlCallback (PlatformInfoHob);
+diff --git a/OvmfPkg/PlatformPei/Platform.h b/OvmfPkg/PlatformPei/Platform.h
+index 0a59547c..e4271101 100644
+--- a/OvmfPkg/PlatformPei/Platform.h
++++ b/OvmfPkg/PlatformPei/Platform.h
+@@ -111,4 +111,14 @@ SevInitializeRam (
+   VOID
+   );
+ 
++VOID
++CsvInitializeMemInfo (
++  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
++  );
++
++VOID
++CsvInitializeGhcb (
++  VOID
++  );
++
+ #endif // _PLATFORM_PEI_H_INCLUDED_
+diff --git a/OvmfPkg/PlatformPei/PlatformPei.inf b/OvmfPkg/PlatformPei/PlatformPei.inf
+index 0bb1a462..75a1b9e4 100644
+--- a/OvmfPkg/PlatformPei/PlatformPei.inf
++++ b/OvmfPkg/PlatformPei/PlatformPei.inf
+@@ -35,6 +35,7 @@
+   PlatformId.h
+   IntelTdx.c
+   SmmRelocation.c
++  Csv.c
+ 
+ [Packages]
+   EmbeddedPkg/EmbeddedPkg.dec
+@@ -71,6 +72,7 @@
+   CcExitLib
+   PlatformInitLib
+   SmmRelocationLib
++  CsvLib
+ 
+ [Pcd]
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase
+@@ -139,6 +141,8 @@
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfWorkAreaSize
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsBase
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsSize
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase
++  gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
+ 
+ [FeaturePcd]
+   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+-- 
+2.25.1
+

--- a/debian/patches/0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
+++ b/debian/patches/0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
@@ -1,0 +1,74 @@
+From c7d72af42ee7146da7e3c14d2a422e8ceef45253 Mon Sep 17 00:00:00 2001
+From: Liu Zixing <liuzixing@hygon.cn>
+Date: Sat, 26 Feb 2022 14:39:06 +0800
+Subject: [PATCH 09/14] OvmfPkg/BaseMemcryptSevLib: update page status to
+ Secure Processor for CSV
+
+For CSV VM, when encrypting/decrypting a shared/private memory region,
+guest needs to
+ - set/clear the c-bit in guest page table
+ - the Secure Processor should be updated accordingly
+
+The BaseMemcryptSevLib has done the first step.
+Calling the secure call library for second step.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ .../BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf   |  1 +
+ .../BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c | 14 ++++++++++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+index 312ee73e..823e5d9d 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+@@ -53,6 +53,7 @@
+   PcdLib
+   CcExitLib
+   AmdSvsmLib
++  CsvLib
+ 
+ [FeaturePcd]
+   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+index 337a7d92..3edea897 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+@@ -19,6 +19,8 @@
+ #include "VirtualMemory.h"
+ #include "SnpPageStateChange.h"
+ 
++#include <Library/CsvLib.h>
++
+ STATIC BOOLEAN          mAddressEncMaskChecked = FALSE;
+ STATIC UINT64           mAddressEncMask;
+ STATIC PAGE_TABLE_POOL  *mPageTablePool = NULL;
+@@ -729,6 +731,11 @@ SetMemoryEncDec (
+   BOOLEAN                         IsWpEnabled;
+   UINTN                           OrigLength;
+   RETURN_STATUS                   Status;
++  PHYSICAL_ADDRESS                PageAddress;
++  UINTN                           PageNum;
++
++  PageAddress = PhysicalAddress;
++  PageNum = EFI_SIZE_TO_PAGES (Length);
+ 
+   //
+   // Set PageMapLevel4Entry to suppress incorrect compiler/analyzer warnings.
+@@ -1012,6 +1019,13 @@ Done:
+     EnableReadOnlyPageWriteProtect ();
+   }
+ 
++  if (CsvIsEnabled () && Status == EFI_SUCCESS) {
++     if (Mode == ClearCBit)
++       CsvUpdateMemory (PageAddress, PageNum, TRUE);
++     else
++       CsvUpdateMemory (PageAddress, PageNum, FALSE);
++   }
++
+   return Status;
+ }
+ 
+-- 
+2.25.1
+

--- a/debian/patches/0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
+++ b/debian/patches/0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
@@ -1,0 +1,41 @@
+From 7d879f58f6e3277d6b7104e28d05e0072753a3fa Mon Sep 17 00:00:00 2001
+From: Xin Jiang <jiangxin@hygon.cn>
+Date: Fri, 18 Aug 2023 17:17:28 +0800
+Subject: [PATCH 10/14] OvmfPkg/Tcg: Add CsvLib for TpmMmioSevDecryptPei
+
+Also add CsvLib to OvmfPkg/IntelTdx/IntelTdxX64.dsc to resolve
+interface dependencies.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/IntelTdx/IntelTdxX64.dsc                          | 1 +
+ OvmfPkg/Tcg/TpmMmioSevDecryptPei/TpmMmioSevDecryptPei.inf | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/OvmfPkg/IntelTdx/IntelTdxX64.dsc b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+index fc133259..7f0105c8 100644
+--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
++++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+@@ -172,6 +172,7 @@
+   PeiHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/PeiHardwareInfoLib.inf
+   DxeHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/DxeHardwareInfoLib.inf
+   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
++  CsvLib|OvmfPkg/Library/CsvLib/CsvLib.inf
+ 
+   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxBaseLib.inf
+   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
+diff --git a/OvmfPkg/Tcg/TpmMmioSevDecryptPei/TpmMmioSevDecryptPei.inf b/OvmfPkg/Tcg/TpmMmioSevDecryptPei/TpmMmioSevDecryptPei.inf
+index 51ad6d0d..402e4c9a 100644
+--- a/OvmfPkg/Tcg/TpmMmioSevDecryptPei/TpmMmioSevDecryptPei.inf
++++ b/OvmfPkg/Tcg/TpmMmioSevDecryptPei/TpmMmioSevDecryptPei.inf
+@@ -29,6 +29,7 @@
+   PcdLib
+   PeimEntryPoint
+   PeiServicesLib
++  CsvLib
+ 
+ [Ppis]
+   gOvmfTpmMmioAccessiblePpiGuid                      ## PRODUCES
+-- 
+2.25.1
+

--- a/debian/patches/0011-OvmfPkg-Add-CsvDxe-driver.patch
+++ b/debian/patches/0011-OvmfPkg-Add-CsvDxe-driver.patch
@@ -1,0 +1,641 @@
+From 96993ce354a9d455758a93c128d146fb6e685278 Mon Sep 17 00:00:00 2001
+From: Liu Zixing <liuzixing@hygon.cn>
+Date: Fri, 25 Feb 2022 16:34:25 +0800
+Subject: [PATCH 11/14] OvmfPkg: Add CsvDxe driver
+
+CsvDxe creates and installs the CsvSharedMemory protocol.
+
+CSV VM needs the shared memory to exchange data with external devices.
+
+To improve the performance, CsvSharedMemory protocol pre-allocates
+huge shared memory chunk as a pool.
+
+When reqeusted,  it allocates small pieces of shared memory from the
+pool and records the allocated memory in a list.
+
+When finished, the shared memory pieces are returned to the pool and
+removed from the record list.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/AmdSev/AmdSevX64.dsc               |   1 +
+ OvmfPkg/AmdSev/AmdSevX64.fdf               |   1 +
+ OvmfPkg/CsvDxe/CsvDxe.c                    | 104 +++++++++++
+ OvmfPkg/CsvDxe/CsvDxe.inf                  |  45 +++++
+ OvmfPkg/CsvDxe/CsvSharedMemory.c           | 208 +++++++++++++++++++++
+ OvmfPkg/CsvDxe/CsvSharedMemory.h           |  29 +++
+ OvmfPkg/Include/Protocol/CsvSharedMemory.h |  99 ++++++++++
+ OvmfPkg/OvmfPkg.dec                        |   1 +
+ OvmfPkg/OvmfPkgIa32X64.dsc                 |   1 +
+ OvmfPkg/OvmfPkgIa32X64.fdf                 |   1 +
+ OvmfPkg/OvmfPkgX64.dsc                     |   1 +
+ OvmfPkg/OvmfPkgX64.fdf                     |   1 +
+ 12 files changed, 492 insertions(+)
+ create mode 100644 OvmfPkg/CsvDxe/CsvDxe.c
+ create mode 100644 OvmfPkg/CsvDxe/CsvDxe.inf
+ create mode 100644 OvmfPkg/CsvDxe/CsvSharedMemory.c
+ create mode 100644 OvmfPkg/CsvDxe/CsvSharedMemory.h
+ create mode 100644 OvmfPkg/Include/Protocol/CsvSharedMemory.h
+
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.dsc b/OvmfPkg/AmdSev/AmdSevX64.dsc
+index 3eb494b3..a69c393a 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
++++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
+@@ -741,6 +741,7 @@
+     PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
+   }
+   OvmfPkg/IoMmuDxe/IoMmuDxe.inf
++  OvmfPkg/CsvDxe/CsvDxe.inf
+ 
+   #
+   # Variable driver stack (non-SMM)
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.fdf b/OvmfPkg/AmdSev/AmdSevX64.fdf
+index a544f80f..6eb9d087 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.fdf
++++ b/OvmfPkg/AmdSev/AmdSevX64.fdf
+@@ -307,6 +307,7 @@ INF  OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
+ INF  OvmfPkg/PlatformDxe/Platform.inf
+ INF  OvmfPkg/AmdSevDxe/AmdSevDxe.inf
+ INF  OvmfPkg/IoMmuDxe/IoMmuDxe.inf
++INF  OvmfPkg/CsvDxe/CsvDxe.inf
+ 
+ 
+ #
+diff --git a/OvmfPkg/CsvDxe/CsvDxe.c b/OvmfPkg/CsvDxe/CsvDxe.c
+new file mode 100644
+index 00000000..d7edf3b9
+--- /dev/null
++++ b/OvmfPkg/CsvDxe/CsvDxe.c
+@@ -0,0 +1,104 @@
++/** @file
++
++  Hygon CSV DXE.
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS, WITHOUT
++  WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Library/BaseLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/DebugLib.h>
++#include <Library/DxeServicesTableLib.h>
++#include <Library/MemoryAllocationLib.h>
++#include <Library/PcdLib.h>
++#include <Library/CsvLib.h>
++#include <Library/UefiBootServicesTableLib.h>
++#include <Protocol/CsvSharedMemory.h>
++#include <Library/MemEncryptSevLib.h>
++#include "CsvSharedMemory.h"
++
++
++#define HUGE_PAGE_SIZE      0x200000ULL
++
++EFI_STATUS
++EFIAPI
++CsvDxeEntryPoint (
++  IN EFI_HANDLE         ImageHandle,
++  IN EFI_SYSTEM_TABLE   *SystemTable
++  )
++{
++  EFI_STATUS                       Status;
++  RETURN_STATUS                    DecryptStatus;
++  CSV_SHARED_MEMORY_PROTOCOL      *SharedMemory;
++  EFI_PHYSICAL_ADDRESS             Memory;
++  EFI_PHYSICAL_ADDRESS             EndMemory;
++  EFI_ALLOCATE_TYPE                AllocateType;
++  UINT64                           Size;
++
++  Status = CsvInstallSharedMemoryProtocol ();
++
++  if (EFI_ERROR (Status)) {
++    DEBUG ((EFI_D_ERROR, "fail to install CsvSharedMemory protocol\n"));
++    return Status;
++  }
++
++  //
++  // Do nothing more when CSV is not enabled
++  //
++  if (!CsvIsEnabled ()) {
++    return EFI_SUCCESS;
++  }
++
++  Status = gBS->LocateProtocol (
++                  &gCsvSharedMemoryProtocolGuid,
++                  NULL,
++                  (VOID**)&SharedMemory
++                  );
++
++  if (Status == EFI_SUCCESS) {
++
++    AllocateType = AllocateMaxAddress;
++    Memory     = BASE_4GB - 1;
++
++    Status = gBS->AllocatePages (
++                    AllocateType,
++                    EfiBootServicesData,
++                    CSV_SHARED_MEMORY_PAGE_NUMBER,
++                    &Memory
++                    );
++
++    if (EFI_ERROR (Status)) {
++      DEBUG ((DEBUG_ERROR, "fail to allocate CsvSharedMemory\n", SharedMemory));
++    } else {
++      //Align to huge page
++      EndMemory = (Memory + CSV_SHARED_MEMORY_SIZE) & (~(HUGE_PAGE_SIZE - 1));
++      Memory = ALIGN_VALUE(Memory, HUGE_PAGE_SIZE);
++      Size  = (EndMemory > Memory) ? EndMemory - Memory : 0;
++      DecryptStatus = MemEncryptSevClearPageEncMask (
++                      0,
++                      Memory,
++                      Size >> EFI_PAGE_SHIFT
++                      );
++      ASSERT_RETURN_ERROR (DecryptStatus);
++
++      SharedMemory->CsvInitializeSharedMemoryList (
++                    SharedMemory,
++                    (UINT64)Memory,
++                    Size
++                    );
++        }
++  } else {
++    DEBUG ((DEBUG_ERROR, "fail to LocateProtocol gCsvSharedMemoryProtocolGuid\n"));
++  }
++
++  return EFI_SUCCESS;
++}
+diff --git a/OvmfPkg/CsvDxe/CsvDxe.inf b/OvmfPkg/CsvDxe/CsvDxe.inf
+new file mode 100644
+index 00000000..0dc88605
+--- /dev/null
++++ b/OvmfPkg/CsvDxe/CsvDxe.inf
+@@ -0,0 +1,45 @@
++#/** @file
++#
++#  Secure Isolated Virtualization
++#
++#  Copyright (c) 2022, HYGON Inc. All rights reserved.<BR>
++#
++#  This program and the accompanying materials are licensed and made available
++#  under the terms and conditions of the BSD License which accompanies this
++#  distribution.  The full text of the license may be found at
++#  http://opensource.org/licenses/bsd-license.php
++#
++#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR
++#  IMPLIED.
++#
++#**/
++
++[Defines]
++  INF_VERSION                    = 1.25
++  BASE_NAME                      = CsvDxe
++  FILE_GUID                      = 829310c0-b9c4-11e9-9e16-9b10d744f884
++  MODULE_TYPE                    = DXE_DRIVER
++  VERSION_STRING                 = 1.0
++  ENTRY_POINT                    = CsvDxeEntryPoint
++
++[Sources]
++  CsvDxe.c
++  CsvSharedMemory.c
++
++[Packages]
++  MdePkg/MdePkg.dec
++  OvmfPkg/OvmfPkg.dec
++
++[LibraryClasses]
++  BaseLib
++  BaseMemoryLib
++  DebugLib
++  CsvLib
++  UefiDriverEntryPoint
++
++[Depex]
++  TRUE
++
++[Protocols]
++  gCsvSharedMemoryProtocolGuid
+diff --git a/OvmfPkg/CsvDxe/CsvSharedMemory.c b/OvmfPkg/CsvDxe/CsvSharedMemory.c
+new file mode 100644
+index 00000000..fbebc615
+--- /dev/null
++++ b/OvmfPkg/CsvDxe/CsvSharedMemory.c
+@@ -0,0 +1,208 @@
++/** @file
++
++  The protocol provides allocate, free the CSV shared memory.
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Library/BaseLib.h>
++#include <Uefi/UefiBaseType.h>
++#include <Library/CsvLib.h>
++#include <Library/MemoryAllocationLib.h>
++#include <Library/DebugLib.h>
++#include <Library/UefiBootServicesTableLib.h>
++#include <Protocol/CsvSharedMemory.h>
++
++
++STATIC LIST_ENTRY        CsvSharedMemoryList  = INITIALIZE_LIST_HEAD_VARIABLE (CsvSharedMemoryList);
++
++//
++//  Insert the initial shared memory address and length to list.
++//
++
++EFI_STATUS
++EFIAPI
++CsvInitializeSharedMemoryList (
++  IN  CSV_SHARED_MEMORY_PROTOCOL  *Protocol,
++  IN  UINT64                      Address,
++  IN  UINT64                      Length
++  )
++{
++  CsvSharedMemoryEntry  *Entry;
++
++  if (Length == 0) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  Entry = AllocatePool (sizeof (*Entry));
++  if (Entry == NULL) {
++    DEBUG((DEBUG_ERROR, "CsvInitializeSharedMemoryList AllocatePool error\n"));
++    return EFI_OUT_OF_RESOURCES;
++  }
++
++  Entry->Start      = Address;
++  Entry->Length     = Length;
++  Entry->Signature  = CSV_SHARED_MEMORY_SIGNATURE;
++
++  InsertTailList (&CsvSharedMemoryList, &Entry->Link);
++
++  return EFI_SUCCESS;
++}
++
++EFI_STATUS
++EFIAPI
++CsvAllocateSharedMemory (
++  IN  CSV_SHARED_MEMORY_PROTOCOL  *Protocol,
++  IN  UINTN                       NumberOfPages,
++  OUT UINT64                      *Memory
++  )
++{
++  LIST_ENTRY             *Link;
++  CsvSharedMemoryEntry   *Entry;
++  UINT64                 MemoryLength;
++
++  MemoryLength = (UINT64)NumberOfPages << EFI_PAGE_SHIFT;
++
++  for (Link = CsvSharedMemoryList.ForwardLink; Link != &CsvSharedMemoryList; Link = Link->ForwardLink) {
++    Entry = CR (Link, CsvSharedMemoryEntry, Link, CSV_SHARED_MEMORY_SIGNATURE);
++    if (Entry->Length > MemoryLength) {
++        *Memory = (EFI_PHYSICAL_ADDRESS)Entry->Start;
++        Entry->Start = *Memory + MemoryLength;
++        Entry->Length -= MemoryLength;
++        break;
++    } else if (Entry->Length == MemoryLength) {
++        *Memory = (EFI_PHYSICAL_ADDRESS)Entry->Start;
++        RemoveEntryList (&Entry->Link);
++        FreePool (Entry);
++        break;
++    }
++  }
++
++
++
++  if (Link == &CsvSharedMemoryList) {
++      DEBUG ((EFI_D_ERROR, "CsvAllocateSharedMemory fail to allocate %u pages\n", NumberOfPages));
++      return EFI_NOT_FOUND;
++  }
++  else {
++      return EFI_SUCCESS;
++  }
++}
++
++
++
++EFI_STATUS
++EFIAPI
++CsvFreeSharedMemory (
++   IN  CSV_SHARED_MEMORY_PROTOCOL  *Protocol,
++   IN  UINTN                       Pages,
++   IN  UINT64                      HostAddress
++  )
++{
++  LIST_ENTRY             *Link;
++  CsvSharedMemoryEntry   *Entry;
++  CsvSharedMemoryEntry   *NewEntry;
++  UINT64                 Memory;
++  UINT64                 MemoryLength;
++  CsvSharedMemoryEntry   *Previous = NULL;
++  BOOLEAN                Inserted = FALSE;
++
++  Memory = (UINT64)HostAddress;
++  MemoryLength = (UINT64)Pages << EFI_PAGE_SHIFT;
++
++  for (Link = CsvSharedMemoryList.ForwardLink;
++       Link != &CsvSharedMemoryList;
++       Link = Link->ForwardLink) {
++    Entry = CR (Link, CsvSharedMemoryEntry, Link, CSV_SHARED_MEMORY_SIGNATURE);
++    if (Inserted)
++      goto Merge;
++    if (Entry->Start + Entry->Length == Memory) {
++      Entry->Length += MemoryLength;
++      Inserted = TRUE;
++      goto Merge;
++    } else if (Memory + MemoryLength < Entry->Start) {
++      NewEntry = AllocatePool (sizeof *NewEntry);
++      if (NewEntry == NULL) {
++        return EFI_OUT_OF_RESOURCES;
++      }
++
++      NewEntry->Start  = Memory;
++      NewEntry->Length = MemoryLength;
++      NewEntry->Signature  = CSV_SHARED_MEMORY_SIGNATURE;
++
++      InsertTailList (&Entry->Link, &NewEntry->Link);
++      break;
++    } else if (Memory + MemoryLength == Entry->Start) {
++      Entry->Start = Memory;
++      Entry->Length += MemoryLength;
++      break;
++    } else if (Link->ForwardLink == &CsvSharedMemoryList) {
++      //
++      // Insert to tail
++      //
++      NewEntry = AllocatePool (sizeof *NewEntry);
++      if (NewEntry == NULL) {
++        return EFI_OUT_OF_RESOURCES;
++      }
++
++      NewEntry->Start  = Memory;
++      NewEntry->Length = MemoryLength;
++      NewEntry->Signature  = CSV_SHARED_MEMORY_SIGNATURE;
++      InsertHeadList (Link, &NewEntry->Link);
++      break;
++    }
++
++Merge:
++    if (Previous) {
++      if (Previous->Start + Previous->Length == Entry->Start) {
++        Entry->Start = Previous->Start;
++        Entry->Length += Previous->Length;
++        RemoveEntryList (&Previous->Link);
++        FreePool (Previous);
++      }
++      break;
++    } else {
++      Previous = Entry;
++    }
++  }
++
++  return EFI_SUCCESS;
++}
++
++CSV_SHARED_MEMORY_PROTOCOL  mCsvSharedMemory = {
++  CsvInitializeSharedMemoryList,
++  CsvAllocateSharedMemory,
++  CsvFreeSharedMemory
++};
++
++/**
++  Initialize CsvSharedMemory Protocol.
++
++**/
++EFI_STATUS
++EFIAPI
++CsvInstallSharedMemoryProtocol (
++  VOID
++  )
++{
++  EFI_STATUS  Status;
++  EFI_HANDLE  Handle;
++
++  Handle = NULL;
++  Status = gBS->InstallMultipleProtocolInterfaces (
++                  &Handle,
++                  &gCsvSharedMemoryProtocolGuid,
++                  &mCsvSharedMemory,
++                  NULL
++                  );
++  return Status;
++}
+diff --git a/OvmfPkg/CsvDxe/CsvSharedMemory.h b/OvmfPkg/CsvDxe/CsvSharedMemory.h
+new file mode 100644
+index 00000000..16348181
+--- /dev/null
++++ b/OvmfPkg/CsvDxe/CsvSharedMemory.h
+@@ -0,0 +1,29 @@
++/** @file
++  CSV shared memory management protocol
++
++  Copyright (C) 2022 HYGON.
++
++  This program and the accompanying materials
++  are licensed and made available under the terms and conditions of the BSD License
++  which accompanies this distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#ifndef _CSV_SHARED_MEMORY_H_
++#define _CSV_SHARED_MEMORY_H_
++
++//
++//  Install SHARED_MEMORY protocol .
++//
++
++EFI_STATUS
++EFIAPI
++CsvInstallSharedMemoryProtocol (
++  VOID
++  );
++
++#endif
+diff --git a/OvmfPkg/Include/Protocol/CsvSharedMemory.h b/OvmfPkg/Include/Protocol/CsvSharedMemory.h
+new file mode 100644
+index 00000000..ba62f3a4
+--- /dev/null
++++ b/OvmfPkg/Include/Protocol/CsvSharedMemory.h
+@@ -0,0 +1,99 @@
++/** @file
++  CSV shared memory management protocol
++
++  Copyright (C) 2022 HYGON.
++
++  This program and the accompanying materials
++  are licensed and made available under the terms and conditions of the BSD License
++  which accompanies this distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#ifndef __PROTOCOL_CSV_SHARED_MEMORY_H__
++#define __PROTOCOL_CSV_SHARED_MEMORY_H__
++
++#define  CSV_SHARED_MEMORY_PAGE_NUMBER       (16384ULL)
++#define  CSV_SHARED_MEMORY_SIZE              ((CSV_SHARED_MEMORY_PAGE_NUMBER)*(SIZE_4KB))
++
++///
++/// Forward declaration
++///
++typedef struct _CSV_SHARED_MEMORY_PROTOCOL CSV_SHARED_MEMORY_PROTOCOL;
++
++
++///
++/// Function prototypes
++///
++
++/**
++  Initialize the list to manage the CSV shared memory.
++  Insert the start address and length.
++
++  @param This           A pointer to CSV_SHARED_MEMORY_PROTOCOL instance.
++  @param Address        The start address of the shared memory.
++  @param Length         The length of the shared memory.
++
++**/
++typedef
++EFI_STATUS
++(EFIAPI *CSV_INITIALIZE_SHARED_MEMORY_LIST)(
++  IN  CSV_SHARED_MEMORY_PROTOCOL *This,
++  IN  UINT64                      Address,
++  IN  UINT64                      Length
++  );
++
++/**
++  Allocate buffer from the shared memory.
++
++  @param This           A pointer to CSV_SHARED_MEMORY_PROTOCOL instance.
++  @param NumberOfPages  The length of page number.
++  @param Memory         When success, allocated memory will be stored in.
++
++  @return  On success, EFI_SUCCESS. Otherwise an errno value
++           indicating the type of failure.
++**/
++typedef
++EFI_STATUS
++(EFIAPI *CSV_ALLOCATE_SHARED_MEMORY)(
++  IN  CSV_SHARED_MEMORY_PROTOCOL *This,
++  IN  UINTN                       NumberOfPages,
++  OUT UINT64                      *Memory
++  );
++
++/**
++  Free buffer to the shared memory.
++
++  @param This           A pointer to CSV_SHARED_MEMORY_PROTOCOL instance.
++  @param NumberOfPages  The page number.
++  @param Memory         The allocated memory to be freed.
++
++  @return  On success, EFI_SUCCESS. Otherwise an errno value
++           indicating the type of failure.
++**/
++typedef
++EFI_STATUS
++(EFIAPI *CSV_FREE_SHARED_MEMORY)(
++  IN  CSV_SHARED_MEMORY_PROTOCOL *This,
++  IN  UINTN                       NumberOfPages,
++  IN  UINT64                      Memory
++  );
++
++///
++/// Protocol structure
++///
++struct _CSV_SHARED_MEMORY_PROTOCOL {
++  //
++  // Protocol data fields
++  //
++  CSV_INITIALIZE_SHARED_MEMORY_LIST   CsvInitializeSharedMemoryList;
++  CSV_ALLOCATE_SHARED_MEMORY          CsvAllocateSharedMemory;
++  CSV_FREE_SHARED_MEMORY              CsvFreeSharedMemory;
++};
++
++extern EFI_GUID gCsvSharedMemoryProtocolGuid;
++
++#endif
+diff --git a/OvmfPkg/OvmfPkg.dec b/OvmfPkg/OvmfPkg.dec
+index dec85152..e7dc7a67 100644
+--- a/OvmfPkg/OvmfPkg.dec
++++ b/OvmfPkg/OvmfPkg.dec
+@@ -200,6 +200,7 @@
+   gQemuAcpiTableNotifyProtocolGuid      = {0x928939b2, 0x4235, 0x462f, {0x95, 0x80, 0xf6, 0xa2, 0xb2, 0xc2, 0x1a, 0x4f}}
+   gEfiMpInitLibMpDepProtocolGuid        = {0xbb00a5ca, 0x8ce,  0x462f, {0xa5, 0x37, 0x43, 0xc7, 0x4a, 0x82, 0x5c, 0xa4}}
+   gEfiMpInitLibUpDepProtocolGuid        = {0xa9e7cef1, 0x5682, 0x42cc, {0xb1, 0x23, 0x99, 0x30, 0x97, 0x3f, 0x4a, 0x9f}}
++  gCsvSharedMemoryProtocolGuid          = {0x0c795ed0, 0xbf0a, 0x11e9, {0x99, 0xbe, 0x50, 0x9a, 0x4c, 0x01, 0x1e, 0xd1}}
+ 
+ [PcdsFixedAtBuild]
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|0x0|UINT32|0
+diff --git a/OvmfPkg/OvmfPkgIa32X64.dsc b/OvmfPkg/OvmfPkgIa32X64.dsc
+index 9e9a22a0..7a8674b6 100644
+--- a/OvmfPkg/OvmfPkgIa32X64.dsc
++++ b/OvmfPkg/OvmfPkgIa32X64.dsc
+@@ -911,6 +911,7 @@
+     PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
+   }
+   OvmfPkg/IoMmuDxe/IoMmuDxe.inf
++  OvmfPkg/CsvDxe/CsvDxe.inf
+ 
+ !if $(SMM_REQUIRE) == TRUE
+   OvmfPkg/SmmAccess/SmmAccess2Dxe.inf
+diff --git a/OvmfPkg/OvmfPkgIa32X64.fdf b/OvmfPkg/OvmfPkgIa32X64.fdf
+index 7711d88e..96f4e832 100644
+--- a/OvmfPkg/OvmfPkgIa32X64.fdf
++++ b/OvmfPkg/OvmfPkgIa32X64.fdf
+@@ -328,6 +328,7 @@ INF  OvmfPkg/PlatformDxe/Platform.inf
+ INF  OvmfPkg/AmdSevDxe/AmdSevDxe.inf
+ INF  OvmfPkg/IoMmuDxe/IoMmuDxe.inf
+ INF  OvmfPkg/VirtHstiDxe/VirtHstiDxe.inf
++INF  OvmfPkg/CsvDxe/CsvDxe.inf
+ 
+ !if $(SMM_REQUIRE) == TRUE
+ INF  OvmfPkg/SmmAccess/SmmAccess2Dxe.inf
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index c428bdd0..c45c6176 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -978,6 +978,7 @@
+     PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
+   }
+   OvmfPkg/IoMmuDxe/IoMmuDxe.inf
++  OvmfPkg/CsvDxe/CsvDxe.inf
+ 
+   OvmfPkg/TdxDxe/TdxDxe.inf
+ 
+diff --git a/OvmfPkg/OvmfPkgX64.fdf b/OvmfPkg/OvmfPkgX64.fdf
+index 0409e513..b1702c42 100644
+--- a/OvmfPkg/OvmfPkgX64.fdf
++++ b/OvmfPkg/OvmfPkgX64.fdf
+@@ -364,6 +364,7 @@ INF  OvmfPkg/PlatformDxe/Platform.inf
+ INF  OvmfPkg/AmdSevDxe/AmdSevDxe.inf
+ INF  OvmfPkg/IoMmuDxe/IoMmuDxe.inf
+ INF  OvmfPkg/VirtHstiDxe/VirtHstiDxe.inf
++INF  OvmfPkg/CsvDxe/CsvDxe.inf
+ 
+ !if $(SMM_REQUIRE) == TRUE
+ INF  OvmfPkg/SmmAccess/SmmAccess2Dxe.inf
+-- 
+2.25.1
+

--- a/debian/patches/0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
+++ b/debian/patches/0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
@@ -1,0 +1,725 @@
+From 01b47de737a6b9cf4fbc80d2721b577c70721f76 Mon Sep 17 00:00:00 2001
+From: Liu Zixing <liuzixing@hygon.cn>
+Date: Fri, 25 Feb 2022 16:54:44 +0800
+Subject: [PATCH 12/14] OvmfPkg/IoMmuDxe: Add CsvIoMmu protocol
+
+Create the dedicated IoMmu protocol for CSV virtual machine.
+And Install it during CSV VM boots up.
+
+It calls the CsvSharedMemoryProtocol to allocate shared memory
+for DMA operations.
+
+- AllocateBuffer() allocates the shared memory.
+
+- FreeBuffer() frees the shared memory.
+
+- Map() does nothing when BusMasterCommonBuffer[64] is requested
+  Otherwise, Map() allocates shared memory.
+
+- Unmap() does nothing when cleaning up a BusMasterCommonBuffer[64]
+  operation. Otherwise, Unmap() frees the shared memory.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/IoMmuDxe/CsvIoMmu.c   | 592 ++++++++++++++++++++++++++++++++++
+ OvmfPkg/IoMmuDxe/CsvIoMmu.h   |  29 ++
+ OvmfPkg/IoMmuDxe/IoMmuDxe.c   |  10 +
+ OvmfPkg/IoMmuDxe/IoMmuDxe.inf |   6 +-
+ 4 files changed, 636 insertions(+), 1 deletion(-)
+ create mode 100644 OvmfPkg/IoMmuDxe/CsvIoMmu.c
+ create mode 100644 OvmfPkg/IoMmuDxe/CsvIoMmu.h
+
+diff --git a/OvmfPkg/IoMmuDxe/CsvIoMmu.c b/OvmfPkg/IoMmuDxe/CsvIoMmu.c
+new file mode 100644
+index 00000000..2a46e984
+--- /dev/null
++++ b/OvmfPkg/IoMmuDxe/CsvIoMmu.c
+@@ -0,0 +1,592 @@
++/** @file
++
++  The protocol provides support to allocate, free, map and umap a DMA buffer
++  for bus master (e.g PciHostBridge). When CSV is enabled, the DMA operations
++  must be performed on non-secure memory so we have to allocate the DMA buffer
++  from non-secure memory.
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#include <Protocol/IoMmu.h>
++
++#include <Library/BaseLib.h>
++#include <Library/DebugLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Library/MemoryAllocationLib.h>
++#include <Library/CsvLib.h>
++#include <Protocol/CsvSharedMemory.h>
++#include <Library/UefiBootServicesTableLib.h>
++#include "CsvIoMmu.h"
++
++#define MAP_INFO_SIG SIGNATURE_64 ('M', 'A', 'P', '_', 'I', 'N', 'F', 'O')
++
++typedef struct {
++  UINT64                                    Signature;
++  LIST_ENTRY                                Link;
++  EDKII_IOMMU_OPERATION                     Operation;
++  UINTN                                     NumberOfBytes;
++  UINTN                                     NumberOfPages;
++  EFI_PHYSICAL_ADDRESS                      SecureAddress;
++  EFI_PHYSICAL_ADDRESS                      UnSecureAddress;
++} MAP_INFO;
++
++//
++// List of the MAP_INFO structures that have been set up by IoMmuMap() and not
++// yet torn down by IoMmuUnmap(). The list represents the full set of mappings
++// currently in effect.
++//
++STATIC LIST_ENTRY mMapInfos = INITIALIZE_LIST_HEAD_VARIABLE (mMapInfos);
++
++//
++// ASCII names for EDKII_IOMMU_OPERATION constants, for debug logging.
++//
++STATIC CONST CHAR8 * CONST
++mBusMasterOperationName[EdkiiIoMmuOperationMaximum] = {
++  "Read",
++  "Write",
++  "CommonBuffer",
++  "Read64",
++  "Write64",
++  "CommonBuffer64"
++};
++
++STATIC CSV_SHARED_MEMORY_PROTOCOL      *SharedMemory;
++STATIC
++EFI_STATUS
++EFIAPI
++CsvAllocSharedPage(
++  IN  UINTN                    Pages,
++  OUT EFI_PHYSICAL_ADDRESS     *Address
++  )
++{
++  EFI_STATUS    Status;
++
++  Status = SharedMemory->CsvAllocateSharedMemory (
++             SharedMemory,
++             Pages,
++             (UINT64*)Address
++             );
++
++  return Status;
++}
++
++STATIC
++EFI_STATUS
++EFIAPI
++CsvFreeSharedPage(
++  IN  UINTN                                    Pages,
++  IN  VOID                                     *HostAddress
++  )
++{
++  EFI_STATUS    Status;
++
++  Status = SharedMemory->CsvFreeSharedMemory (
++             SharedMemory,
++             Pages,
++             (UINTN)HostAddress
++             );
++
++  return Status;
++}
++
++/**
++  Provides the controller-specific addresses required to access system memory
++  from a DMA bus master.
++  On CSV guest, the DMA openerations must be done on non-secure memory which
++  is the shared memory between the guest and QEMU.
++
++  @param  This                  The protocol instance pointer.
++  @param  Operation             Indicates if the bus master is going to read or
++                                write to system memory.
++  @param  HostAddress           The system memory address to map to the PCI
++                                controller.
++  @param  NumberOfBytes         On input the number of bytes to map. On output
++                                the number of bytes that were mapped.
++  @param  DeviceAddress         The resulting map address for the bus master
++                                PCI controller to use to access the hosts
++                                HostAddress.
++  @param  Mapping               A resulting value to pass to Unmap().
++
++  @retval EFI_SUCCESS           The range was mapped for the returned
++                                NumberOfBytes.
++  @retval EFI_UNSUPPORTED       The HostAddress cannot be mapped as a common
++                                buffer.
++  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
++  @retval EFI_OUT_OF_RESOURCES  The request could not be completed due to a
++                                lack of resources.
++  @retval EFI_DEVICE_ERROR      The system hardware could not map the requested
++                                address.
++
++**/
++EFI_STATUS
++EFIAPI
++CsvIoMmuMap (
++  IN     EDKII_IOMMU_PROTOCOL                       *This,
++  IN     EDKII_IOMMU_OPERATION                      Operation,
++  IN     VOID                                       *HostAddress,
++  IN OUT UINTN                                      *NumberOfBytes,
++  OUT    EFI_PHYSICAL_ADDRESS                       *DeviceAddress,
++  OUT    VOID                                       **Mapping
++  )
++{
++  EFI_STATUS                                        Status;
++  MAP_INFO                                          *MapInfo;
++
++  DEBUG ((
++    DEBUG_VERBOSE,
++    "%a: Operation=%a Operation=%u Host=0x%p Bytes=0x%Lx\n",
++    __FUNCTION__,
++    ((Operation >= 0 &&
++      Operation < ARRAY_SIZE (mBusMasterOperationName)) ?
++     mBusMasterOperationName[Operation] :
++     "Invalid"),
++    Operation,
++    HostAddress,
++    (UINT64)((NumberOfBytes == NULL) ? 0 : *NumberOfBytes)
++    ));
++
++  if (HostAddress == NULL || NumberOfBytes == NULL || DeviceAddress == NULL ||
++      Mapping == NULL) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  //
++  // Allocate a MAP_INFO structure to remember the mapping when Unmap() is
++  // called later.
++  //
++  MapInfo = AllocatePool (sizeof (MAP_INFO));
++  if (MapInfo == NULL) {
++    Status = EFI_OUT_OF_RESOURCES;
++    goto Failed;
++  }
++
++  ZeroMem (&MapInfo->Link, sizeof MapInfo->Link);
++  MapInfo->Operation         = Operation;
++  MapInfo->NumberOfBytes     = *NumberOfBytes;
++  MapInfo->NumberOfPages     = EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes);
++  MapInfo->Signature         = MAP_INFO_SIG;
++
++  switch (Operation) {
++  //
++  // For BusMasterRead[64] and BusMasterWrite[64] operations, a bounce buffer
++  // is necessary regardless of whether the original (crypted) buffer crosses
++  // the 4GB limit or not -- we have to allocate a separate plaintext buffer.
++  // The only variable is whether the plaintext buffer should be under 4GB.
++  //
++  case EdkiiIoMmuOperationBusMasterRead:
++  case EdkiiIoMmuOperationBusMasterWrite:
++    //
++    // fall through
++    //
++  case EdkiiIoMmuOperationBusMasterRead64:
++  case EdkiiIoMmuOperationBusMasterWrite64:
++    //
++    // Allocate the implicit plaintext bounce buffer.
++    //
++    Status = CsvAllocSharedPage (
++               MapInfo->NumberOfPages,
++               &MapInfo->UnSecureAddress
++               );
++    if (EFI_ERROR (Status)) {
++      goto FreeMapInfo;
++    }
++    MapInfo->SecureAddress = (UINTN)HostAddress;
++    if (Operation == EdkiiIoMmuOperationBusMasterRead ||
++        Operation == EdkiiIoMmuOperationBusMasterRead64) {
++      CopyMem (
++        (VOID *) (UINTN) MapInfo->UnSecureAddress,
++        (VOID *) (UINTN) MapInfo->SecureAddress,
++        MapInfo->NumberOfBytes
++        );
++    }
++    break;
++
++  //
++  // For BusMasterCommonBuffer[64] operations,
++  // AllocateBuffer already returns the plain-text,
++  // No need to decrypt the data.
++  //
++  case EdkiiIoMmuOperationBusMasterCommonBuffer:
++  case EdkiiIoMmuOperationBusMasterCommonBuffer64:
++    MapInfo->UnSecureAddress = (UINTN)HostAddress;
++    MapInfo->SecureAddress   = (UINTN)HostAddress;
++    break;
++
++  default:
++    //
++    // Operation is invalid
++    //
++    Status = EFI_INVALID_PARAMETER;
++    goto FreeMapInfo;
++  }
++
++  //
++  // Track all MAP_INFO structures.
++  //
++  InsertHeadList (&mMapInfos, &MapInfo->Link);
++  //
++  // Populate output parameters.
++  //
++  *DeviceAddress = MapInfo->UnSecureAddress;
++  *Mapping       = MapInfo;
++
++  DEBUG ((
++    DEBUG_VERBOSE,
++    "%a: Mapping=0x%p Device=0x%Lx Host=0x%Lx Pages=0x%Lx\n",
++    __FUNCTION__,
++    MapInfo,
++    MapInfo->UnSecureAddress,
++    MapInfo->SecureAddress,
++    (UINT64)MapInfo->NumberOfPages
++    ));
++
++  return EFI_SUCCESS;
++
++FreeMapInfo:
++  FreePool (MapInfo);
++
++Failed:
++  *NumberOfBytes = 0;
++  return Status;
++}
++
++/**
++  Completes the Map() operation and releases any corresponding resources.
++
++  This is an internal worker function that only extends the Map() API with
++  the MemoryMapLocked parameter.
++
++  @param  This                  The protocol instance pointer.
++  @param  Mapping               The mapping value returned from Map().
++  @param  MemoryMapLocked       The function is executing on the stack of
++                                gBS->ExitBootServices(); changes to the UEFI
++                                memory map are forbidden.
++
++  @retval EFI_SUCCESS           The range was unmapped.
++  @retval EFI_INVALID_PARAMETER Mapping is not a value that was returned by
++                                Map().
++  @retval EFI_DEVICE_ERROR      The data was not committed to the target system
++                                memory.
++**/
++STATIC
++EFI_STATUS
++EFIAPI
++CsvIoMmuUnmapWorker (
++  IN  EDKII_IOMMU_PROTOCOL                     *This,
++  IN  VOID                                     *Mapping,
++  IN  BOOLEAN                                  MemoryMapLocked
++  )
++{
++  MAP_INFO                 *MapInfo;
++  EDKII_IOMMU_OPERATION    Operation;
++
++  if (Mapping == NULL) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  MapInfo = (MAP_INFO *)Mapping;
++  Operation = MapInfo->Operation;
++
++  DEBUG ((
++    DEBUG_VERBOSE,
++    "%a: Mapping=0x%p MemoryMapLocked=%d Operation %a Operation %d\n",
++    __FUNCTION__,
++    Mapping,
++    MemoryMapLocked,
++    ((Operation >= 0 &&
++      Operation < ARRAY_SIZE (mBusMasterOperationName)) ?
++     mBusMasterOperationName[Operation] :
++     "Invalid"),
++     Operation
++    ));
++
++  switch (MapInfo->Operation) {
++  case EdkiiIoMmuOperationBusMasterWrite:
++  case EdkiiIoMmuOperationBusMasterWrite64:
++    CopyMem (
++      (VOID *) (UINTN) MapInfo->SecureAddress,
++      (VOID *) (UINTN) MapInfo->UnSecureAddress,
++      MapInfo->NumberOfBytes
++      );
++  case EdkiiIoMmuOperationBusMasterRead:
++  case EdkiiIoMmuOperationBusMasterRead64:
++    ZeroMem (
++      (VOID *)(UINTN)MapInfo->UnSecureAddress,
++      EFI_PAGES_TO_SIZE (MapInfo->NumberOfPages)
++      );
++    CsvFreeSharedPage(
++      MapInfo->NumberOfPages,
++      (VOID*)(UINTN)MapInfo->UnSecureAddress
++      );
++
++  default:
++    break;
++  }
++
++  //
++  // Forget the MAP_INFO structure, then free it (unless the UEFI memory map is
++  // locked).
++  //
++  RemoveEntryList (&MapInfo->Link);
++  if (!MemoryMapLocked) {
++    FreePool (MapInfo);
++  }
++
++  return EFI_SUCCESS;
++
++}
++
++/**
++  Completes the Map() operation and releases any corresponding resources.
++
++  @param  This                  The protocol instance pointer.
++  @param  Mapping               The mapping value returned from Map().
++
++  @retval EFI_SUCCESS           The range was unmapped.
++  @retval EFI_INVALID_PARAMETER Mapping is not a value that was returned by
++                                Map().
++  @retval EFI_DEVICE_ERROR      The data was not committed to the target system
++                                memory.
++**/
++EFI_STATUS
++EFIAPI
++CsvIoMmuUnmap (
++  IN  EDKII_IOMMU_PROTOCOL                     *This,
++  IN  VOID                                     *Mapping
++  )
++{
++  return CsvIoMmuUnmapWorker (
++           This,
++           Mapping,
++           FALSE    // MemoryMapLocked
++           );
++}
++
++/**
++  Allocates pages that are suitable for an OperationBusMasterCommonBuffer or
++  OperationBusMasterCommonBuffer64 mapping.
++
++  @param  This                  The protocol instance pointer.
++  @param  Type                  This parameter is not used and must be ignored.
++  @param  MemoryType            The type of memory to allocate,
++                                EfiBootServicesData or EfiRuntimeServicesData.
++  @param  Pages                 The number of pages to allocate.
++  @param  HostAddress           A pointer to store the base system memory
++                                address of the allocated range.
++  @param  Attributes            The requested bit mask of attributes for the
++                                allocated range.
++
++  @retval EFI_SUCCESS           The requested memory pages were allocated.
++  @retval EFI_UNSUPPORTED       Attributes is unsupported. The only legal
++                                attribute bits are MEMORY_WRITE_COMBINE and
++                                MEMORY_CACHED.
++  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
++  @retval EFI_OUT_OF_RESOURCES  The memory pages could not be allocated.
++
++**/
++EFI_STATUS
++EFIAPI
++CsvIoMmuAllocateBuffer (
++  IN     EDKII_IOMMU_PROTOCOL                     *This,
++  IN     EFI_ALLOCATE_TYPE                        Type,
++  IN     EFI_MEMORY_TYPE                          MemoryType,
++  IN     UINTN                                    Pages,
++  IN OUT VOID                                     **HostAddress,
++  IN     UINT64                                   Attributes
++  )
++{
++  EFI_STATUS                Status;
++  EFI_PHYSICAL_ADDRESS      PhysicalAddress;
++
++  DEBUG ((
++    DEBUG_VERBOSE,
++    "%a: MemoryType=%u Pages=0x%Lx Attributes=0x%Lx\n",
++    __FUNCTION__,
++    (UINT32)MemoryType,
++    (UINT64)Pages,
++    Attributes
++    ));
++
++  //
++  // Validate Attributes
++  //
++  if ((Attributes & EDKII_IOMMU_ATTRIBUTE_INVALID_FOR_ALLOCATE_BUFFER) != 0) {
++    return EFI_UNSUPPORTED;
++  }
++
++  //
++  // Check for invalid inputs
++  //
++  if (HostAddress == NULL) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  //
++  // The only valid memory types are EfiBootServicesData and
++  // EfiRuntimeServicesData
++  //
++  if (MemoryType != EfiBootServicesData &&
++      MemoryType != EfiRuntimeServicesData) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  //
++  // We'll need a header page for the COMMON_BUFFER_HEADER structure.
++  //
++  if (Pages > MAX_UINTN - 1) {
++    return EFI_OUT_OF_RESOURCES;
++  }
++
++  Status = CsvAllocSharedPage (Pages,&PhysicalAddress);
++  if (Status != EFI_SUCCESS){
++    goto error;
++  }
++
++
++  *HostAddress = (VOID *)(UINTN)PhysicalAddress;
++
++  return EFI_SUCCESS;
++
++error:
++  return Status;
++}
++
++/**
++  Frees memory that was allocated with AllocateBuffer().
++
++  @param  This                  The protocol instance pointer.
++  @param  Pages                 The number of pages to free.
++  @param  HostAddress           The base system memory address of the allocated
++                                range.
++
++  @retval EFI_SUCCESS           The requested memory pages were freed.
++  @retval EFI_INVALID_PARAMETER The memory range specified by HostAddress and
++                                Pages was not allocated with AllocateBuffer().
++
++**/
++EFI_STATUS
++EFIAPI
++CsvIoMmuFreeBuffer (
++  IN  EDKII_IOMMU_PROTOCOL                     *This,
++  IN  UINTN                                    Pages,
++  IN  VOID                                     *HostAddress
++  )
++{
++
++  EFI_STATUS                Status;
++
++  if (HostAddress == NULL || Pages == 0) {
++      return EFI_INVALID_PARAMETER;
++  }
++
++  DEBUG ((
++    DEBUG_VERBOSE,
++    "%a: Host=0x%p Pages=0x%Lx\n",
++    __FUNCTION__,
++    HostAddress,
++    (UINT64)Pages
++    ));
++
++  Status = CsvFreeSharedPage (Pages, HostAddress);
++
++  return Status;
++}
++
++
++/**
++  Set IOMMU attribute for a system memory.
++
++  @param[in]  This              The protocol instance pointer.
++  @param[in]  DeviceHandle      The device who initiates the DMA access
++                                request.
++  @param[in]  Mapping           The mapping value returned from Map().
++  @param[in]  IoMmuAccess       The IOMMU access.
++
++  @retval EFI_SUCCESS            The IoMmuAccess is set for the memory range
++                                 specified by DeviceAddress and Length.
++  @retval EFI_INVALID_PARAMETER  DeviceHandle is an invalid handle.
++  @retval EFI_INVALID_PARAMETER  Mapping is not a value that was returned by
++                                 Map().
++  @retval EFI_INVALID_PARAMETER  IoMmuAccess specified an illegal combination
++                                 of access.
++  @retval EFI_UNSUPPORTED        DeviceHandle is unknown by the IOMMU.
++  @retval EFI_UNSUPPORTED        The bit mask of IoMmuAccess is not supported
++                                 by the IOMMU.
++  @retval EFI_UNSUPPORTED        The IOMMU does not support the memory range
++                                 specified by Mapping.
++  @retval EFI_OUT_OF_RESOURCES   There are not enough resources available to
++                                 modify the IOMMU access.
++  @retval EFI_DEVICE_ERROR       The IOMMU device reported an error while
++                                 attempting the operation.
++
++**/
++EFI_STATUS
++EFIAPI
++CsvIoMmuSetAttribute (
++  IN EDKII_IOMMU_PROTOCOL  *This,
++  IN EFI_HANDLE            DeviceHandle,
++  IN VOID                  *Mapping,
++  IN UINT64                IoMmuAccess
++  )
++{
++  return EFI_UNSUPPORTED;
++}
++
++EDKII_IOMMU_PROTOCOL  mCsv = {
++  EDKII_IOMMU_PROTOCOL_REVISION,
++  CsvIoMmuSetAttribute,
++  CsvIoMmuMap,
++  CsvIoMmuUnmap,
++  CsvIoMmuAllocateBuffer,
++  CsvIoMmuFreeBuffer,
++};
++
++/**
++  Initialize Iommu Protocol.
++
++**/
++EFI_STATUS
++EFIAPI
++CsvInstallIoMmuProtocol (
++  VOID
++  )
++{
++  EFI_STATUS  Status;
++  EFI_HANDLE  Handle;
++
++  Status = gBS->LocateProtocol (
++                  &gCsvSharedMemoryProtocolGuid,
++                  NULL,
++                  (VOID**)&SharedMemory
++                  );
++
++  if (EFI_ERROR (Status)) {
++    goto error;
++  }
++
++  Handle = NULL;
++  Status = gBS->InstallMultipleProtocolInterfaces (
++                  &Handle,
++                  &gEdkiiIoMmuProtocolGuid,
++                  &mCsv,
++                  NULL
++                  );
++  if (EFI_ERROR (Status)) {
++    goto error;
++  }
++
++  return EFI_SUCCESS;
++
++error:
++  return Status;
++}
+diff --git a/OvmfPkg/IoMmuDxe/CsvIoMmu.h b/OvmfPkg/IoMmuDxe/CsvIoMmu.h
+new file mode 100644
+index 00000000..431d2843
+--- /dev/null
++++ b/OvmfPkg/IoMmuDxe/CsvIoMmu.h
+@@ -0,0 +1,29 @@
++/** @file
++
++  The protocol provides support to allocate, free, map and umap a DMA buffer
++  for bus master (e.g PciHostBridge). When CSV is enabled, the DMA operations
++  must be performed on unencrypted buffer hence protocol clear the encryption
++  bit from the DMA buffer.
++
++  Copyright (c) 2022, HYGON. All rights reserved.<BR>
++
++  This program and the accompanying materials are licensed and made available
++  under the terms and conditions of the BSD License which accompanies this
++  distribution.  The full text of the license may be found at
++  http://opensource.org/licenses/bsd-license.php
++
++  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
++  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
++
++**/
++
++#ifndef _CSV_IOMMU_H_
++#define _CSV_IOMMU_H_
++
++EFI_STATUS
++EFIAPI
++CsvInstallIoMmuProtocol (
++  VOID
++  );
++
++#endif
+diff --git a/OvmfPkg/IoMmuDxe/IoMmuDxe.c b/OvmfPkg/IoMmuDxe/IoMmuDxe.c
+index aab6d8b9..cd03ca90 100644
+--- a/OvmfPkg/IoMmuDxe/IoMmuDxe.c
++++ b/OvmfPkg/IoMmuDxe/IoMmuDxe.c
+@@ -10,6 +10,8 @@
+ **/
+ 
+ #include "CcIoMmu.h"
++#include <Library/CsvLib.h>
++#include "CsvIoMmu.h"
+ 
+ EFI_STATUS
+ EFIAPI
+@@ -21,6 +23,14 @@ IoMmuDxeEntryPoint (
+   EFI_STATUS  Status;
+   EFI_HANDLE  Handle;
+ 
++  if (CsvIsEnabled ()) {
++    Status = CsvInstallIoMmuProtocol ();
++    if (Status != EFI_SUCCESS) {
++      DEBUG((EFI_D_ERROR, "fail to install CSV IOMMU\n"));
++    }
++    return Status;
++  }
++
+   //
+   // When SEV or TDX is enabled, install IoMmu protocol otherwise install the
+   // placeholder protocol so that other dependent module can run.
+diff --git a/OvmfPkg/IoMmuDxe/IoMmuDxe.inf b/OvmfPkg/IoMmuDxe/IoMmuDxe.inf
+index d08f7e59..d16e940b 100644
+--- a/OvmfPkg/IoMmuDxe/IoMmuDxe.inf
++++ b/OvmfPkg/IoMmuDxe/IoMmuDxe.inf
+@@ -22,6 +22,8 @@
+   CcIoMmu.h
+   IoMmuDxe.c
+   IoMmuBuffer.c
++  CsvIoMmu.c
++  CsvIoMmu.h
+ 
+ [Packages]
+   MdePkg/MdePkg.dec
+@@ -38,6 +40,7 @@
+   SynchronizationLib
+   UefiBootServicesTableLib
+   UefiDriverEntryPoint
++  CsvLib
+ 
+ [Pcd]
+   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr
+@@ -45,6 +48,7 @@
+ [Protocols]
+   gEdkiiIoMmuProtocolGuid                     ## SOMETIME_PRODUCES
+   gIoMmuAbsentProtocolGuid                    ## SOMETIME_PRODUCES
++  gCsvSharedMemoryProtocolGuid
+ 
+ [Depex]
+-  TRUE
++  gCsvSharedMemoryProtocolGuid
+-- 
+2.25.1
+

--- a/debian/patches/0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
+++ b/debian/patches/0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
@@ -1,0 +1,67 @@
+From c27fcf2381d0a19fbfd8a4d4b15eba95066a6c56 Mon Sep 17 00:00:00 2001
+From: lilu <lilu@hygon.cn>
+Date: Thu, 7 Sep 2023 14:44:59 +0800
+Subject: [PATCH 13/14] OvmfPkg: Use classic mmio window for CSV guest
+
+For CSV guest, firmware restricts gpa range. Dynamic mmio window
+sets Mmio64Base exceeding firmware restriction. Use classic mmio
+window for CSV guest. Classic mmio window is less than firmware
+restriction under real circumstances.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/Library/CsvLib/CsvLib.inf                   | 2 +-
+ OvmfPkg/Library/PlatformInitLib/MemDetect.c         | 4 +++-
+ OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf | 1 +
+ 3 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/OvmfPkg/Library/CsvLib/CsvLib.inf b/OvmfPkg/Library/CsvLib/CsvLib.inf
+index 57efbe70..bcb6546f 100644
+--- a/OvmfPkg/Library/CsvLib/CsvLib.inf
++++ b/OvmfPkg/Library/CsvLib/CsvLib.inf
+@@ -21,7 +21,7 @@
+   FILE_GUID                      = 9460ef3a-b9c3-11e9-8324-7371ac35e1e3
+   MODULE_TYPE                    = BASE
+   VERSION_STRING                 = 1.0
+-  LIBRARY_CLASS                  = CsvLib|PEIM DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_DRIVER
++  LIBRARY_CLASS                  = CsvLib|SEC PEIM DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_DRIVER
+ 
+ #
+ # The following information is for reference only and not required by the build
+diff --git a/OvmfPkg/Library/PlatformInitLib/MemDetect.c b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+index fa6cce7e..b86fa1ad 100644
+--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
++++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+@@ -40,6 +40,7 @@ Module Name:
+ #include <Library/QemuFwCfgLib.h>
+ #include <Library/QemuFwCfgSimpleParserLib.h>
+ #include <Library/TdxLib.h>
++#include <Library/CsvLib.h>
+ 
+ #include <Library/PlatformInitLib.h>
+ 
+@@ -761,7 +762,8 @@ PlatformDynamicMmioWindow (
+   AddrSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth);
+   MmioSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth - 3);
+ 
+-  if ((PlatformInfoHob->PcdPciMmio64Size < MmioSpace) &&
++  if (!CsvIsEnabled() &&
++      (PlatformInfoHob->PcdPciMmio64Size < MmioSpace) &&
+       (PlatformInfoHob->PcdPciMmio64Base + MmioSpace < AddrSpace))
+   {
+     DEBUG ((DEBUG_INFO, "%a: using dynamic mmio window\n", __func__));
+diff --git a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+index 21e6efa5..8ff294d2 100644
+--- a/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
++++ b/OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+@@ -52,6 +52,7 @@
+   PcdLib
+   PciLib
+   PeiHardwareInfoLib
++  CsvLib
+ 
+ [LibraryClasses.X64]
+   TdxLib
+-- 
+2.25.1
+

--- a/debian/patches/0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
+++ b/debian/patches/0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
@@ -1,0 +1,82 @@
+From 29683fed90b3be40bb9d862bdd258c98bdbe3a1b Mon Sep 17 00:00:00 2001
+From: Xin Jiang <jiangxin@hygon.cn>
+Date: Mon, 20 May 2024 13:53:17 +0800
+Subject: [PATCH 14/14] OvmfPkg/IoMmuDxe: Implement SetAttribute() of CsvIoMmu
+
+As PciIoMap() adds feedback with the status of SetAttribute ()
+return value, it is necessary to implement SetAttribute () for
+CsvIoMmu to fix the CSV3 boot up failure issue.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+Signed-off-by: hanliyang <hanliyang@hygon.cn>
+---
+ OvmfPkg/IoMmuDxe/CsvIoMmu.c | 53 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 52 insertions(+), 1 deletion(-)
+
+diff --git a/OvmfPkg/IoMmuDxe/CsvIoMmu.c b/OvmfPkg/IoMmuDxe/CsvIoMmu.c
+index 2a46e984..755ef06c 100644
+--- a/OvmfPkg/IoMmuDxe/CsvIoMmu.c
++++ b/OvmfPkg/IoMmuDxe/CsvIoMmu.c
+@@ -539,7 +539,58 @@ CsvIoMmuSetAttribute (
+   IN UINT64                IoMmuAccess
+   )
+ {
+-  return EFI_UNSUPPORTED;
++  MAP_INFO    *MapInfo;
++  EFI_STATUS  Status;
++
++  DEBUG ((DEBUG_VERBOSE, "%a: Mapping=0x%p Access=%lu\n", __func__, Mapping, IoMmuAccess));
++
++  if (Mapping == NULL) {
++    return EFI_INVALID_PARAMETER;
++  }
++
++  Status = EFI_SUCCESS;
++
++  //
++  // An IoMmuAccess value of 0 is always accepted, validate any non-zero value.
++  //
++  if (IoMmuAccess != 0) {
++    MapInfo = (MAP_INFO *)Mapping;
++
++    //
++    // The mapping operation already implied the access mode. Validate that
++    // the supplied access mode matches operation access mode.
++    //
++    switch (MapInfo->Operation) {
++      case EdkiiIoMmuOperationBusMasterRead:
++      case EdkiiIoMmuOperationBusMasterRead64:
++        if (IoMmuAccess != EDKII_IOMMU_ACCESS_READ) {
++          Status = EFI_INVALID_PARAMETER;
++        }
++
++        break;
++
++      case EdkiiIoMmuOperationBusMasterWrite:
++      case EdkiiIoMmuOperationBusMasterWrite64:
++        if (IoMmuAccess != EDKII_IOMMU_ACCESS_WRITE) {
++          Status = EFI_INVALID_PARAMETER;
++        }
++
++        break;
++
++      case EdkiiIoMmuOperationBusMasterCommonBuffer:
++      case EdkiiIoMmuOperationBusMasterCommonBuffer64:
++        if (IoMmuAccess != (EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)) {
++          Status = EFI_INVALID_PARAMETER;
++        }
++
++        break;
++
++      default:
++        Status = EFI_UNSUPPORTED;
++    }
++  }
++
++  return Status;
+ }
+ 
+ EDKII_IOMMU_PROTOCOL  mCsv = {
+-- 
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,14 @@ mbedtls-disable.diff
 0001-MdePkg-BaseLib-RISC-V-Add-FPU-CSR-constants.patch
 0002-UefiCpuPkg-RiscV64-initialize-FPU.patch
 0003-OvmfPkg-RiscV64-build-BaseRiscVFpuLib.patch
+0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
+0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
+0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
+0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
+0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
+0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
+0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
+0011-OvmfPkg-Add-CsvDxe-driver.patch
+0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
+0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
+0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch


### PR DESCRIPTION
CSV3 provides an enhancement technology named memory isolation to improve the security. A
dedicated memory isolation hardware is built in Hygon hardware. Only the secure processor
has privilege to configure the isolation hardware. The VMM allocates CMA memory and transfers
them to secure processor. The secure processor maps the memory to secure nested page table
and manages them as guest's private memory. Any memory access (read or write) to CSV3 guest's
private memory outside the guest will be blocked by isolation hardware.

```
0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
- Add Hygon platform detection code
0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
- Delete the 2nd SendIpi messages in SendInitSipiSipi and SendInitSipiSipiAllExcludingSelf for Hygon guest.
0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
- Add CSV3 secure call library. The secure call provides a secure data exchange channel between the CSV3 guest and the security processor.
0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
- Support CSV3 function in ResetVector phase.
0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
- Initialize the memory of the current CSV3 guest.
0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
- Update page enc/dec status of the current CSV3 guest.
0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
- Support compile with TpmMmio.
0011-OvmfPkg-Add-CsvDxe-driver.patch
- Add CSV3 DXE driver. The driver creates and installs the CSV3 shared memory protocol for supporting data exchange with peripherals.
0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
- Add CSV3 iommu protocol. This driver creates a proprietary iommu protocol for the CSV3 guest to support operations such as DMA.
0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
- Limited by the MMIO range of the CSV3 firmware, the CSV3 guest uses the classic MMIO address range.
0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
- The commit 049695a0b1 ("MdeModulePkg/PciBusDxe: Add feedback status for PciIoMap") has adds feedback with the status of SetAttribute () return value in PciIoMap (), it is necessary to implement SetAttribute () for CsvIoMmu to fix the CSV3 boot up failure issue.
```


## How to test:
#### Code requirement:
- Linux Kernel (both host and guest use this kernel, https://github.com/deepin-community/kernel/tree/linux-6.6.y, commit 96767233880246ea3a33825d2998f21f3c8741a5);
- Qemu (https://github.com/deepin-community/qemu/tree/master + https://github.com/deepin-community/qemu/pull/22);
- Edk2 (https://github.com/deepin-community/edk2/tree/master + https://github.com/deepin-community/edk2/pull/4);
#### Generated binaries:
- Linux Kernel:  deb packages of the kernel, install these packages on both the host and guest, reboot the host with this new kernel.
> * Linux cmdline must contains: `csv_mem_percentage=@xxx kvm-amd.sev=1 kvm-amd.sev_es=1`. The `@xxx` is decimal number, for example, 50 means provide 50% of the total main memory for CSV3 guest at most. 
> * The CPU must support CSV3 hardware feature.
> * Run command `dmesg | grep 'CSV3 enabled'`, if we see `CSV: CSV3 enabled (ASIDs ...)` at the host side，it means we can launch and run CSV3 guest.
- Qemu: assume the qemu bin is installed to /usr/bin/qemu-system-x86_64
- Edk2: assuem the OVMF bin is installed to /usr/share/OVMF/OVMF_CODE_4M.fd
#### Create and run CSV3 guest
- Qemu command line
```
/usr/bin/qemu-system-x86_64 \
-enable-kvm -cpu host -smp 40 -m 10G \
-drive if=pflash,format=raw,unit=0,file=/usr/share/OVMF/OVMF_CODE_4M.fd,readonly=on \
-object sev-guest,id=sev0,policy=0x45,cbitpos=47,reduced-phys-bits=5 \
-machine memory-encryption=sev0 -machine q35 \
-device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=on \
-drive file=./vm.qcow2,if=none,id=drive0 -device scsi-hd,drive=drive0,bootindex=1 \
-vnc 0.0.0.0:0,to=90
```
- login the CSV3 guest
> Run command `dmesg | grep CSV3` at the guest side, if we see `HYGON CSV3`, it means CSV3 security feature is active for this guest.