### PR TITLE
Support live migration for Hygon CSV1/2/3 guest, fix nesting #VC Exception

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,17 +1,32 @@
+edk2 (2024.08-2deepin2) unstable; urgency=medium
+
+  * Support live migration for Hygon CSV/CSV2/CSV3 guest, fix nesting #VC:
+    - d/p/0015-OvmfPkg-BaseMemEncryptLib-Detect-SEV-live-migration-.patch
+    - d/p/0016-OvmfPkg-BaseMemEncryptLib-Hypercall-API-for-page-enc.patch
+    - d/p/0017-OvmfPkg-BaseMemEncryptLib-Invoke-page-encryption-sta.patch
+    - d/p/0018-OvmfPkg-VmgExitLib-Encryption-state-change-hypercall.patch
+    - d/p/0019-OvmfPkg-PlatformPei-Mark-SEC-GHCB-page-as-unencrypte.patch
+    - d/p/0020-OvmfPkg-AmdSevDxe-Add-support-for-SEV-live-migration.patch
+    - d/p/0021-OvmfPkg-BaseMemcryptSevLib-Correct-the-calculation-o.patch
+    - d/p/0022-OvmfPkg-BaseMemEncryptLib-Return-SUCCESS-if-not-supp.patch
+    - d/p/0023-OvmfPkg-BaseMemEncryptLib-Save-memory-encrypt-status.patch
+
+ -- hanliyang <hanliyang@hygon.cn>  Mon, 14 Oct 2024 15:34:28 +0000
+
 edk2 (2024.08-2deepin1) unstable; urgency=medium
 
- * Add support for Hygon CSV3 feature:
-   - d/p/0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
-   - d/p/0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
-   - d/p/0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
-   - d/p/0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
-   - d/p/0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
-   - d/p/0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
-   - d/p/0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
-   - d/p/0011-OvmfPkg-Add-CsvDxe-driver.patch
-   - d/p/0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
-   - d/p/0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
-   - d/p/0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
+  * Add support for Hygon CSV3 feature:
+    - d/p/0004-MdePkg-Add-StandardSignatureIsHygonGenuine-in-BaseCp.patch
+    - d/p/0005-UefiCpuPkg-LocalApicLib-Exclude-second-SendIpi-seque.patch
+    - d/p/0006-OvmfPkg-Add-CSV-secure-call-library-on-Hygon-CPU.patch
+    - d/p/0007-OvmfPkg-ResetVector-Support-CSV-in-ResetVector-phase.patch
+    - d/p/0008-OvmfPkg-PlatformPei-Initialize-CSV-VM-s-memory.patch
+    - d/p/0009-OvmfPkg-BaseMemcryptSevLib-update-page-status-to-Sec.patch
+    - d/p/0010-OvmfPkg-Tcg-Add-CsvLib-for-TpmMmioSevDecryptPei.patch
+    - d/p/0011-OvmfPkg-Add-CsvDxe-driver.patch
+    - d/p/0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
+    - d/p/0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
+    - d/p/0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
 
  -- hanliyang <hanliyang@hygon.cn>  Wed, 09 Oct 2024 21:26:28 +0000
 

--- a/debian/patches/0015-OvmfPkg-BaseMemEncryptLib-Detect-SEV-live-migration-.patch
+++ b/debian/patches/0015-OvmfPkg-BaseMemEncryptLib-Detect-SEV-live-migration-.patch
@@ -1,0 +1,330 @@
+From bcc36056f955538e01e9c2a8940cecbbb877ad64 Mon Sep 17 00:00:00 2001
+From: Ashish Kalra <ashish.kalra@amd.com>
+Date: Tue, 5 Apr 2022 16:09:28 +0000
+Subject: [PATCH 1/9] OvmfPkg/BaseMemEncryptLib: Detect SEV live migration
+ feature.
+
+cherry-picked from https://patchew.org/EDK2/cover.1629380011.git.ashish.kalra@amd.com .
+
+Add support to check if we are running inside KVM HVM and
+KVM HVM supports SEV Live Migration feature.
+
+Cc: Jordan Justen <jordan.l.justen@intel.com>
+Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
+Signed-off-by: Ashish Kalra <ashish.kalra@amd.com>
+---
+ OvmfPkg/Include/Library/MemEncryptSevLib.h    | 12 ++++
+ .../DxeMemEncryptSevLibInternal.c             | 49 ++++++++++++++--
+ .../PeiDxeMemEncryptSevLibInternal.c          | 58 +++++++++++++++++++
+ .../PeiDxeMemEncryptSevLibInternal.h          | 31 ++++++++++
+ .../PeiMemEncryptSevLibInternal.c             | 42 ++++++++++++++
+ .../SecMemEncryptSevLibInternal.c             | 18 ++++++
+ 6 files changed, 206 insertions(+), 4 deletions(-)
+ create mode 100644 OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.h
+
+diff --git a/OvmfPkg/Include/Library/MemEncryptSevLib.h b/OvmfPkg/Include/Library/MemEncryptSevLib.h
+index c5653539..dac87256 100644
+--- a/OvmfPkg/Include/Library/MemEncryptSevLib.h
++++ b/OvmfPkg/Include/Library/MemEncryptSevLib.h
+@@ -83,6 +83,18 @@ MemEncryptSevIsEnabled (
+   VOID
+   );
+ 
++/**
++  Returns a boolean to indicate whether SEV live migration is enabled.
++
++  @retval TRUE           SEV live migration is enabled
++  @retval FALSE          SEV live migration is not enabled
++**/
++BOOLEAN
++EFIAPI
++MemEncryptSevLiveMigrationIsEnabled (
++  VOID
++  );
++
+ /**
+   This function clears memory encryption bit for the memory region specified by
+   BaseAddress and NumPages from the current page table context.
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
+index 9947d663..b2a68bae 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
+@@ -18,10 +18,14 @@
+ #include <Uefi/UefiBaseType.h>
+ #include <ConfidentialComputingGuestAttr.h>
+ 
+-STATIC UINT64   mCurrentAttr            = 0;
+-STATIC BOOLEAN  mCurrentAttrRead        = FALSE;
+-STATIC UINT64   mSevEncryptionMask      = 0;
+-STATIC BOOLEAN  mSevEncryptionMaskSaved = FALSE;
++#include "PeiDxeMemEncryptSevLibInternal.h"
++
++STATIC UINT64   mCurrentAttr                   = 0;
++STATIC BOOLEAN  mCurrentAttrRead               = FALSE;
++STATIC UINT64   mSevEncryptionMask             = 0;
++STATIC BOOLEAN  mSevEncryptionMaskSaved        = FALSE;
++STATIC BOOLEAN  mSevLiveMigrationStatus        = FALSE;
++STATIC BOOLEAN  mSevLiveMigrationStatusChecked = FALSE;
+ 
+ /**
+   The function check if the specified Attr is set.
+@@ -117,6 +121,24 @@ MemEncryptSevSnpIsEnabled (
+   return ConfidentialComputingGuestHas (CCAttrAmdSevSnp);
+ }
+ 
++/**
++  Figures out if we are running inside KVM HVM and
++  KVM HVM supports SEV Live Migration feature.
++**/
++STATIC
++VOID
++EFIAPI
++InternalDetectSevLiveMigrationFeature (
++  VOID
++  )
++{
++  if (KvmDetectSevLiveMigrationFeature ()) {
++    mSevLiveMigrationStatus = TRUE;
++  }
++
++  mSevLiveMigrationStatusChecked = TRUE;
++}
++
+ /**
+   Returns a boolean to indicate whether SEV-ES is enabled.
+ 
+@@ -147,6 +169,25 @@ MemEncryptSevIsEnabled (
+   return ConfidentialComputingGuestHas (CCAttrAmdSev);
+ }
+ 
++/**
++  Returns a boolean to indicate whether SEV live migration is enabled.
++
++  @retval TRUE           SEV live migration is enabled
++  @retval FALSE          SEV live migration is not enabled
++**/
++BOOLEAN
++EFIAPI
++MemEncryptSevLiveMigrationIsEnabled (
++  VOID
++  )
++{
++  if (!mSevLiveMigrationStatusChecked) {
++    InternalDetectSevLiveMigrationFeature ();
++  }
++
++  return mSevLiveMigrationStatus;
++}
++
+ /**
+   Returns the SEV encryption mask.
+ 
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.c b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.c
+index 43a2a3e3..30e1d8d0 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.c
+@@ -16,6 +16,8 @@
+ #include <Register/SmramSaveStateMap.h>
+ #include <Uefi/UefiBaseType.h>
+ 
++#include "PeiDxeMemEncryptSevLibInternal.h"
++
+ /**
+   Locate the page range that covers the initial (pre-SMBASE-relocation) SMRAM
+   Save State Map.
+@@ -61,3 +63,59 @@ MemEncryptSevLocateInitialSmramSaveStateMapPages (
+ 
+   return RETURN_SUCCESS;
+ }
++
++/**
++  Figures out if we are running inside KVM HVM and
++  KVM HVM supports SEV Live Migration feature.
++
++  @retval TRUE           SEV live migration is supported.
++  @retval FALSE          SEV live migration is not supported.
++**/
++BOOLEAN
++EFIAPI
++KvmDetectSevLiveMigrationFeature (
++  VOID
++  )
++{
++  CHAR8   Signature[13];
++  UINT32  mKvmLeaf;
++  UINT32  RegEax;
++  UINT32  RegEbx;
++  UINT32  RegEcx;
++  UINT32  RegEdx;
++
++  Signature[12] = '\0';
++  for (mKvmLeaf = 0x40000000; mKvmLeaf < 0x40010000; mKvmLeaf += 0x100) {
++    AsmCpuid (
++      mKvmLeaf,
++      NULL,
++      (UINT32 *)&Signature[0],
++      (UINT32 *)&Signature[4],
++      (UINT32 *)&Signature[8]
++      );
++
++    if (AsciiStrCmp (Signature, "KVMKVMKVM") == 0) {
++      DEBUG ((
++        DEBUG_INFO,
++        "%a: KVM Detected, signature = %a\n",
++        __FUNCTION__,
++        Signature
++        ));
++
++      RegEax = mKvmLeaf + 1;
++      RegEcx = 0;
++      AsmCpuid (mKvmLeaf + 1, &RegEax, &RegEbx, &RegEcx, &RegEdx);
++      if ((RegEax & KVM_FEATURE_MIGRATION_CONTROL) != 0) {
++        DEBUG ((
++          DEBUG_INFO,
++          "%a: SEV Live Migration feature supported\n",
++          __FUNCTION__
++          ));
++
++        return TRUE;
++      }
++    }
++  }
++
++  return FALSE;
++}
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.h b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.h
+new file mode 100644
+index 00000000..b0ef053c
+--- /dev/null
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiDxeMemEncryptSevLibInternal.h
+@@ -0,0 +1,31 @@
++/** @file
++
++  Secure Encrypted Virtualization (SEV) library helper function
++
++  Copyright (c) 2021, AMD Incorporated. All rights reserved.<BR>
++
++  SPDX-License-Identifier: BSD-2-Clause-Patent
++
++**/
++
++#ifndef PEI_DXE_MEM_ENCRYPT_SEV_LIB_INTERNAL_H_
++#define PEI_DXE_MEM_ENCRYPT_SEV_LIB_INTERNAL_H_
++
++#include <Library/BaseLib.h>
++
++#define KVM_FEATURE_MIGRATION_CONTROL  BIT17
++
++/**
++  Figures out if we are running inside KVM HVM and
++  KVM HVM supports SEV Live Migration feature.
++
++  @retval TRUE           SEV live migration is supported.
++  @retval FALSE          SEV live migration is not supported.
++**/
++BOOLEAN
++EFIAPI
++KvmDetectSevLiveMigrationFeature (
++  VOID
++  );
++
++#endif // PEI_DXE_MEM_ENCRYPT_SEV_LIB_INTERNAL_H_
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
+index f381b925..b20ffc11 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLibInternal.c
+@@ -17,6 +17,11 @@
+ #include <Register/Cpuid.h>
+ #include <Uefi/UefiBaseType.h>
+ 
++#include "PeiDxeMemEncryptSevLibInternal.h"
++
++STATIC BOOLEAN  mSevLiveMigrationStatus        = FALSE;
++STATIC BOOLEAN  mSevLiveMigrationStatusChecked = FALSE;
++
+ /**
+    Read the workarea to determine whether SEV is enabled. If enabled,
+    then return the SevEsWorkArea pointer.
+@@ -83,6 +88,24 @@ MemEncryptSevSnpIsEnabled (
+   return Msr.Bits.SevSnpBit ? TRUE : FALSE;
+ }
+ 
++/**
++  Figures out if we are running inside KVM HVM and
++  KVM HVM supports SEV Live Migration feature.
++**/
++STATIC
++VOID
++EFIAPI
++InternalDetectSevLiveMigrationFeature (
++  VOID
++  )
++{
++  if (KvmDetectSevLiveMigrationFeature ()) {
++    mSevLiveMigrationStatus = TRUE;
++  }
++
++  mSevLiveMigrationStatusChecked = TRUE;
++}
++
+ /**
+   Returns a boolean to indicate whether SEV-ES is enabled.
+ 
+@@ -121,6 +144,25 @@ MemEncryptSevIsEnabled (
+   return Msr.Bits.SevBit ? TRUE : FALSE;
+ }
+ 
++/**
++  Returns a boolean to indicate whether SEV live migration is enabled.
++
++  @retval TRUE           SEV live migration is enabled
++  @retval FALSE          SEV live migration is not enabled
++**/
++BOOLEAN
++EFIAPI
++MemEncryptSevLiveMigrationIsEnabled (
++  VOID
++  )
++{
++  if (!mSevLiveMigrationStatusChecked) {
++    InternalDetectSevLiveMigrationFeature ();
++  }
++
++  return mSevLiveMigrationStatus;
++}
++
+ /**
+   Returns the SEV encryption mask.
+ 
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+index 946bed2a..0e5faa1b 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+@@ -121,6 +121,24 @@ MemEncryptSevIsEnabled (
+   return Msr.Bits.SevBit ? TRUE : FALSE;
+ }
+ 
++/**
++  Returns a boolean to indicate whether SEV live migration is enabled.
++
++  @retval TRUE           SEV live migration is enabled
++  @retval FALSE          SEV live migration is not enabled
++**/
++BOOLEAN
++EFIAPI
++MemEncryptSevLiveMigrationIsEnabled (
++  VOID
++  )
++{
++  //
++  // Not used in SEC phase.
++  //
++  return FALSE;
++}
++
+ /**
+   Returns the SEV encryption mask.
+ 
+-- 
+2.25.1
+

--- a/debian/patches/0016-OvmfPkg-BaseMemEncryptLib-Hypercall-API-for-page-enc.patch
+++ b/debian/patches/0016-OvmfPkg-BaseMemEncryptLib-Hypercall-API-for-page-enc.patch
@@ -1,0 +1,301 @@
+From 1cf6687d535122afd57410375f2ce2de0d4b1f0f Mon Sep 17 00:00:00 2001
+From: Ashish Kalra <ashish.kalra@amd.com>
+Date: Tue, 5 Apr 2022 16:23:53 +0000
+Subject: [PATCH 2/9] OvmfPkg/BaseMemEncryptLib: Hypercall API for page
+ encryption state change
+
+cherry-picked from https://patchew.org/EDK2/cover.1629380011.git.ashish.kalra@amd.com .
+
+Add API to issue hypercall on page encryption state change.
+
+By default all the SEV guest memory regions are considered encrypted,
+if a guest changes the encryption attribute of the page (e.g mark a
+page as decrypted) then notify hypervisor. Hypervisor will need to
+track the unencrypted pages. The information will be used during
+guest live migration, guest page migration and guest debugging.
+
+This hypercall is used to notify hypervisor when the page's
+encryption state changes.
+
+Cc: Jordan Justen <jordan.l.justen@intel.com>
+Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
+Signed-off-by: Brijesh Singh <brijesh.singh@amd.com>
+Signed-off-by: Ashish Kalra <ashish.kalra@amd.com>
+---
+ OvmfPkg/Include/Library/MemEncryptSevLib.h    | 52 +++++++++++++++
+ .../DxeMemEncryptSevLib.inf                   |  1 +
+ .../Ia32/MemEncryptSevLib.c                   | 27 ++++++++
+ .../PeiMemEncryptSevLib.inf                   |  1 +
+ .../SecMemEncryptSevLibInternal.c             | 20 ++++++
+ .../X64/AsmHelperStub.nasm                    | 33 ++++++++++
+ .../X64/MemEncryptSevLib.c                    | 66 +++++++++++++++++++
+ 7 files changed, 200 insertions(+)
+ create mode 100644 OvmfPkg/Library/BaseMemEncryptSevLib/X64/AsmHelperStub.nasm
+
+diff --git a/OvmfPkg/Include/Library/MemEncryptSevLib.h b/OvmfPkg/Include/Library/MemEncryptSevLib.h
+index dac87256..5d2841cc 100644
+--- a/OvmfPkg/Include/Library/MemEncryptSevLib.h
++++ b/OvmfPkg/Include/Library/MemEncryptSevLib.h
+@@ -252,4 +252,56 @@ MemEncryptSevSnpPreValidateSystemRam (
+   IN UINTN             NumPages
+   );
+ 
++/**
++ This hypercall is used to notify hypervisor when the page's encryption
++ state changes.
++
++ @param[in]   PhysicalAddress       The physical address that is the start address
++                                    of a memory region.
++ @param[in]   Pages                 Number of pages in memory region.
++ @param[in]   IsEncrypted           Encrypted or Decrypted.
++
++ @retval RETURN_SUCCESS             Hypercall returned success.
++ @retval RETURN_UNSUPPORTED         Hypercall not supported.
++ @retval RETURN_NO_MAPPING          Hypercall returned error.
++**/
++RETURN_STATUS
++EFIAPI
++SetMemoryEncDecHypercall3 (
++  IN  UINTN    PhysicalAddress,
++  IN  UINTN    Pages,
++  IN  BOOLEAN  IsEncrypted
++  );
++
++#define KVM_HC_MAP_GPA_RANGE          12
++#define KVM_MAP_GPA_RANGE_PAGE_SZ_4K  0
++#define KVM_MAP_GPA_RANGE_PAGE_SZ_2M  BIT0
++#define KVM_MAP_GPA_RANGE_PAGE_SZ_1G  BIT1
++#define KVM_MAP_GPA_RANGE_ENC_STATE(n)  ((n) << 4)
++#define KVM_MAP_GPA_RANGE_ENCRYPTED  KVM_MAP_GPA_RANGE_ENC_STATE(1)
++#define KVM_MAP_GPA_RANGE_DECRYPTED  KVM_MAP_GPA_RANGE_ENC_STATE(0)
++
++/**
++ Interface exposed by the ASM implementation of the core hypercall
++
++ @param[in]   HypercallNum          KVM_HC_MAP_GPA_RANGE hypercall.
++ @param[in]   PhysicalAddress       The physical address that is the start address
++                                    of a memory region.
++ @param[in]   Pages                 Number of pages in memory region.
++ @param[in]   Attributes            Bits 3:0 - preferred page size encoding,
++                                    0 = 4kb, 1 = 2mb, 2 = 1gb, etc...
++                                    Bit  4 - plaintext = 0, encrypted = 1
++                                    Bits 63:5 - reserved (must be zero)
++
++  @retval Hypercall returned status.
++**/
++UINTN
++EFIAPI
++SetMemoryEncDecHypercall3AsmStub (
++  IN  UINTN  HypercallNum,
++  IN  UINTN  PhysicalAddress,
++  IN  UINTN  Pages,
++  IN  UINTN  Attributes
++  );
++
+ #endif // _MEM_ENCRYPT_SEV_LIB_H_
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+index 823e5d9d..2ad0c7ee 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+@@ -40,6 +40,7 @@
+   X64/SnpPageStateChangeInternal.c
+   X64/VirtualMemory.c
+   X64/VirtualMemory.h
++  X64/AsmHelperStub.nasm
+ 
+ [Sources.IA32]
+   Ia32/MemEncryptSevLib.c
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/Ia32/MemEncryptSevLib.c b/OvmfPkg/Library/BaseMemEncryptSevLib/Ia32/MemEncryptSevLib.c
+index f92299fc..c1c10a61 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/Ia32/MemEncryptSevLib.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/Ia32/MemEncryptSevLib.c
+@@ -153,3 +153,30 @@ MemEncryptSevSnpPreValidateSystemRam (
+ {
+   ASSERT (FALSE);
+ }
++
++/**
++ This hyercall is used to notify hypervisor when the page's encryption
++ state changes.
++
++ @param[in]   PhysicalAddress       The physical address that is the start address
++                                    of a memory region.
++ @param[in]   Pages                 Number of Pages in the memory region.
++ @param[in]   IsEncrypted           Encrypted or Decrypted.
++
++ @retval RETURN_SUCCESS             Hypercall returned success.
++ @retval RETURN_UNSUPPORTED         Hypercall not supported.
++ @retval RETURN_NO_MAPPING          Hypercall returned error.
++**/
++RETURN_STATUS
++EFIAPI
++SetMemoryEncDecHypercall3 (
++  IN  UINTN    PhysicalAddress,
++  IN  UINTN    Pages,
++  IN  BOOLEAN  IsEncrypted
++  )
++{
++  //
++  // Memory encryption bit is not accessible in 32-bit mode
++  //
++  return RETURN_UNSUPPORTED;
++}
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
+index 1e0b5600..7479161a 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
+@@ -40,6 +40,7 @@
+   X64/SnpPageStateChangeInternal.c
+   X64/VirtualMemory.c
+   X64/VirtualMemory.h
++  X64/AsmHelperStub.nasm
+ 
+ [Sources.IA32]
+   Ia32/MemEncryptSevLib.c
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+index 0e5faa1b..2d7a256a 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/SecMemEncryptSevLibInternal.c
+@@ -139,6 +139,26 @@ MemEncryptSevLiveMigrationIsEnabled (
+   return FALSE;
+ }
+ 
++/**
++  Interface exposed by the ASM implementation of the core hypercall
++
++  @retval Hypercall returned status.
++**/
++UINTN
++EFIAPI
++SetMemoryEncDecHypercall3AsmStub (
++  IN  UINTN  HypercallNum,
++  IN  UINTN  PhysicalAddress,
++  IN  UINTN  Pages,
++  IN  UINTN  Attributes
++  )
++{
++  //
++  // Not used in SEC phase.
++  //
++  return RETURN_UNSUPPORTED;
++}
++
+ /**
+   Returns the SEV encryption mask.
+ 
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/AsmHelperStub.nasm b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/AsmHelperStub.nasm
+new file mode 100644
+index 00000000..0ec35dd9
+--- /dev/null
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/AsmHelperStub.nasm
+@@ -0,0 +1,33 @@
++/** @file
++
++  ASM helper stub to invoke hypercall
++
++  Copyright (c) 2021, AMD Incorporated. All rights reserved.<BR>
++
++  SPDX-License-Identifier: BSD-2-Clause-Patent
++
++**/
++
++DEFAULT REL
++SECTION .text
++
++; UINTN
++; EFIAPI
++; SetMemoryEncDecHypercall3AsmStub (
++;   IN UINTN HypercallNum,
++;   IN UINTN Arg1,
++;   IN UINTN Arg2,
++;   IN UINTN Arg3
++;   );
++global ASM_PFX(SetMemoryEncDecHypercall3AsmStub)
++ASM_PFX(SetMemoryEncDecHypercall3AsmStub):
++  ; UEFI calling conventions require RBX to
++  ; be nonvolatile/callee-saved.
++  push rbx
++  mov rax, rcx    ; Copy HypercallNumber to rax
++  mov rbx, rdx    ; Copy Arg1 to the register expected by KVM
++  mov rcx, r8     ; Copy Arg2 to register expected by KVM
++  mov rdx, r9     ; Copy Arg3 to register expected by KVM
++  vmmcall         ; Call VMMCALL
++  pop rbx
++  ret
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c
+index e7c703bb..a64ff2a5 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c
+@@ -142,3 +142,69 @@ MemEncryptSevClearMmioPageEncMask (
+            EFI_PAGES_TO_SIZE (NumPages)
+            );
+ }
++
++/**
++ This hyercall is used to notify hypervisor when the page's encryption
++ state changes.
++
++ @param[in]   PhysicalAddress       The physical address that is the start address
++                                    of a memory region.
++ @param[in]   Pages                 Number of Pages in the memory region.
++ @param[in]   IsEncrypted           Encrypted or Decrypted.
++
++ @retval RETURN_SUCCESS             Hypercall returned success.
++ @retval RETURN_UNSUPPORTED         Hypercall not supported.
++ @retval RETURN_NO_MAPPING          Hypercall returned error.
++**/
++RETURN_STATUS
++EFIAPI
++SetMemoryEncDecHypercall3 (
++  IN  UINTN    PhysicalAddress,
++  IN  UINTN    Pages,
++  IN  BOOLEAN  IsEncrypted
++  )
++{
++  RETURN_STATUS  Ret;
++  UINTN          Error;
++  UINTN          EncryptState;
++
++  Ret = RETURN_UNSUPPORTED;
++
++  if (MemEncryptSevLiveMigrationIsEnabled ()) {
++    Ret = RETURN_SUCCESS;
++    //
++    // The encryption bit is set/clear on the smallest page size, hence
++    // use the 4k page size in MAP_GPA_RANGE hypercall below.
++    //
++    // Also, when the GCD map is being walked and the c-bit being cleared
++    // from MMIO and NonExistent memory spaces, the physical address
++    // range being passed may not be page-aligned and adding an assert
++    // here prevents booting. Hence, rounding it down when calling
++    // SetMemoryEncDecHypercall3AsmStub below.
++    //
++
++    EncryptState = IsEncrypted ? KVM_MAP_GPA_RANGE_ENCRYPTED :
++                   KVM_MAP_GPA_RANGE_DECRYPTED;
++
++    Error = SetMemoryEncDecHypercall3AsmStub (
++              KVM_HC_MAP_GPA_RANGE,
++              PhysicalAddress & ~EFI_PAGE_MASK,
++              Pages,
++              KVM_MAP_GPA_RANGE_PAGE_SZ_4K | EncryptState
++              );
++
++    if (Error != 0) {
++      DEBUG ((
++        DEBUG_ERROR,
++        "SetMemoryEncDecHypercall3 failed, Phys = %x, Pages = %d, Err = %Ld\n",
++        PhysicalAddress,
++        Pages,
++        (INT64)Error
++        ));
++
++      Ret = RETURN_NO_MAPPING;
++    }
++  }
++
++  return Ret;
++}
+-- 
+2.25.1
+

--- a/debian/patches/0017-OvmfPkg-BaseMemEncryptLib-Invoke-page-encryption-sta.patch
+++ b/debian/patches/0017-OvmfPkg-BaseMemEncryptLib-Invoke-page-encryption-sta.patch
@@ -1,0 +1,84 @@
+From 76259c7b4db5506784a41a64aacba61acec2f945 Mon Sep 17 00:00:00 2001
+From: Ashish Kalra <ashish.kalra@amd.com>
+Date: Tue, 5 Apr 2022 16:26:02 +0000
+Subject: [PATCH 3/9] OvmfPkg/BaseMemEncryptLib: Invoke page encryption state
+ change hypercall
+
+cherry-picked from https://patchew.org/EDK2/cover.1629380011.git.ashish.kalra@amd.com .
+
+Invoke the hypercall API to notify hypervisor when the page's
+encryption state changes.
+
+Cc: Jordan Justen <jordan.l.justen@intel.com>
+Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
+Signed-off-by: Brijesh Singh <brijesh.singh@amd.com>
+Signed-off-by: Ashish Kalra <ashish.kalra@amd.com>
+---
+ .../X64/PeiDxeVirtualMemory.c                    | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+index 3edea897..c52e80ba 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+@@ -729,6 +729,7 @@ SetMemoryEncDec (
+   UINT64                          PgTableMask;
+   UINT64                          AddressEncMask;
+   BOOLEAN                         IsWpEnabled;
++  BOOLEAN                         CBitChanged;
+   UINTN                           OrigLength;
+   RETURN_STATUS                   Status;
+   PHYSICAL_ADDRESS                PageAddress;
+@@ -814,6 +815,7 @@ SetMemoryEncDec (
+   // Save the specified length and physical address (we need it later).
+   //
+   OrigLength          = Length;
++  CBitChanged         = FALSE;
+   OrigPhysicalAddress = PhysicalAddress;
+ 
+   while (Length != 0) {
+@@ -874,6 +876,7 @@ SetMemoryEncDec (
+           ));
+         PhysicalAddress += BIT30;
+         Length          -= BIT30;
++        CBitChanged      = TRUE;
+       } else {
+         //
+         // We must split the page
+@@ -929,6 +932,7 @@ SetMemoryEncDec (
+           SetOrClearCBit (&PageDirectory2MEntry->Uint64, Mode);
+           PhysicalAddress += BIT21;
+           Length          -= BIT21;
++          CBitChanged      = TRUE;
+         } else {
+           //
+           // We must split up this page into 4K pages
+@@ -972,6 +976,7 @@ SetMemoryEncDec (
+         SetOrClearCBit (&PageTableEntry->Uint64, Mode);
+         PhysicalAddress += EFI_PAGE_SIZE;
+         Length          -= EFI_PAGE_SIZE;
++        CBitChanged      = TRUE;
+       }
+     }
+   }
+@@ -1011,6 +1016,17 @@ SetMemoryEncDec (
+       );
+   }
+ 
++  //
++  // Notify Hypervisor on C-bit status
++  //
++  if (CBitChanged) {
++    Status = SetMemoryEncDecHypercall3 (
++               OrigPhysicalAddress,
++               EFI_SIZE_TO_PAGES (OrigLength),
++               (Mode == SetCBit) ? TRUE : FALSE
++               );
++  }
++
+ Done:
+   //
+   // Restore page table write protection, if any.
+-- 
+2.25.1
+

--- a/debian/patches/0018-OvmfPkg-VmgExitLib-Encryption-state-change-hypercall.patch
+++ b/debian/patches/0018-OvmfPkg-VmgExitLib-Encryption-state-change-hypercall.patch
@@ -1,0 +1,47 @@
+From 4e69934f54c0f93ad758196f650057c5a6750bed Mon Sep 17 00:00:00 2001
+From: Ashish Kalra <ashish.kalra@amd.com>
+Date: Tue, 5 Apr 2022 16:27:26 +0000
+Subject: [PATCH 4/9] OvmfPkg/VmgExitLib: Encryption state change hypercall
+ support in VC handler
+
+cherry-picked from https://patchew.org/EDK2/cover.1629380011.git.ashish.kalra@amd.com .
+
+Make the #VC handler aware of the page encryption state
+change hypercall by adding support to check KVM_HC_MAP_GPA_RANGE
+hypercall and add the additional register values used by
+hypercall in the GHCB.
+
+Cc: Jordan Justen <jordan.l.justen@intel.com>
+Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
+Signed-off-by: Ashish Kalra <ashish.kalra@amd.com>
+---
+ OvmfPkg/Library/CcExitLib/CcExitVcHandler.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+index 2031fa9e..681b7e20 100644
+--- a/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
++++ b/OvmfPkg/Library/CcExitLib/CcExitVcHandler.c
+@@ -662,6 +662,19 @@ VmmCallExit (
+   Ghcb->SaveArea.Cpl = (UINT8)(Regs->Cs & 0x3);
+   CcExitVmgSetOffsetValid (Ghcb, GhcbCpl);
+ 
++  if (Regs->Rax == KVM_HC_MAP_GPA_RANGE) {
++    //
++    // KVM_HC_MAP_GPA_RANGE hypercall requires these
++    // extra registers.
++    //
++    Ghcb->SaveArea.Rbx = Regs->Rbx;
++    CcExitVmgSetOffsetValid (Ghcb, GhcbRbx);
++    Ghcb->SaveArea.Rcx = Regs->Rcx;
++    CcExitVmgSetOffsetValid (Ghcb, GhcbRcx);
++    Ghcb->SaveArea.Rdx = Regs->Rdx;
++    CcExitVmgSetOffsetValid (Ghcb, GhcbRdx);
++  }
++
+   Status = CcExitVmgExit (Ghcb, SVM_EXIT_VMMCALL, 0, 0);
+   if (Status != 0) {
+     return Status;
+-- 
+2.25.1
+

--- a/debian/patches/0019-OvmfPkg-PlatformPei-Mark-SEC-GHCB-page-as-unencrypte.patch
+++ b/debian/patches/0019-OvmfPkg-PlatformPei-Mark-SEC-GHCB-page-as-unencrypte.patch
@@ -1,0 +1,44 @@
+From 6e6fb9b64b829eeb8eb994c2e25f7ce5d8b02bbd Mon Sep 17 00:00:00 2001
+From: Ashish Kalra <ashish.kalra@amd.com>
+Date: Tue, 5 Apr 2022 16:30:54 +0000
+Subject: [PATCH 5/9] OvmfPkg/PlatformPei: Mark SEC GHCB page as unencrypted
+ via hypercall
+
+cherry-picked from https://patchew.org/EDK2/cover.1629380011.git.ashish.kalra@amd.com .
+
+Mark the SEC GHCB page (that is mapped as unencrypted in
+ResetVector code) in the hypervisor's guest page encryption
+state tracking.
+
+Cc: Jordan Justen <jordan.l.justen@intel.com>
+Cc: Ard Biesheuvel <ard.biesheuvel@arm.com>
+Signed-off-by: Ashish Kalra <ashish.kalra@amd.com>
+---
+ OvmfPkg/PlatformPei/AmdSev.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/OvmfPkg/PlatformPei/AmdSev.c b/OvmfPkg/PlatformPei/AmdSev.c
+index 85627870..30e8a012 100644
+--- a/OvmfPkg/PlatformPei/AmdSev.c
++++ b/OvmfPkg/PlatformPei/AmdSev.c
+@@ -319,6 +319,17 @@ AmdSevEsInitialize (
+   Status = PcdSetBoolS (PcdSevEsIsEnabled, TRUE);
+   ASSERT_RETURN_ERROR (Status);
+ 
++  //
++  // The SEC Ghcb setup during reset-vector needs to be marked as
++  // decrypted in the hypervisor's guest page encryption state
++  // tracking.
++  //
++  SetMemoryEncDecHypercall3 (
++    FixedPcdGet32 (PcdOvmfSecGhcbBase),
++    EFI_SIZE_TO_PAGES (FixedPcdGet32 (PcdOvmfSecGhcbSize)),
++    FALSE
++    );
++
+   //
+   // Allocate GHCB and per-CPU variable pages.
+   //   Since the pages must survive across the UEFI to OS transition
+-- 
+2.25.1
+

--- a/debian/patches/0020-OvmfPkg-AmdSevDxe-Add-support-for-SEV-live-migration.patch
+++ b/debian/patches/0020-OvmfPkg-AmdSevDxe-Add-support-for-SEV-live-migration.patch
@@ -1,0 +1,196 @@
+From 2dc6d0b2bfaa55b4959652bb9320279bc67b8ef1 Mon Sep 17 00:00:00 2001
+From: Ashish Kalra <ashish.kalra@amd.com>
+Date: Tue, 5 Apr 2022 16:40:03 +0000
+Subject: [PATCH 6/9] OvmfPkg/AmdSevDxe: Add support for SEV live migration.
+
+cherry-picked from https://patchew.org/EDK2/cover.1629380011.git.ashish.kalra@amd.com .
+
+Check for SEV live migration feature support, if detected
+setup a new UEFI enviroment variable to indicate OVMF
+support for SEV live migration.
+
+This environment variable is created by UEFI but consumed
+by the (guest) linux kernel. This is actually part of a
+3-way negotiation of the live migration feature between
+hypervisor, guest OVMF and guest kernel. Host indicates
+support for live migration, which is detected by OVMF
+and correspondingly OVMF sets this SetLiveMigrationEnabled
+UEFI variable, which is read by the guest kernel and it
+indicates to the guest kernel that both host and OVMF
+support and have enabled the live migration feature.
+
+The new runtime UEFI environment variable is set via the
+notification function registered for the
+EFI_END_OF_DXE_EVENT_GROUP_GUID event in AmdSevDxe driver.
+
+AmdSevDxe module is an apriori driver so it gets loaded between PEI
+and DXE phases and the SetVariable call will fail at the driver's
+entry point as the Variable DXE module is still not loaded yet.
+So we need to wait for an event notification which is signaled
+after the Variable DXE module is loaded, hence, using the
+EndOfDxe event notification to make this call.
+
+Signed-off-by: Ashish Kalra <ashish.kalra@amd.com>
+---
+ OvmfPkg/AmdSevDxe/AmdSevDxe.c              | 67 ++++++++++++++++++++++
+ OvmfPkg/AmdSevDxe/AmdSevDxe.inf            |  4 ++
+ OvmfPkg/Include/Guid/AmdSevMemEncryptLib.h | 20 +++++++
+ OvmfPkg/OvmfPkg.dec                        |  1 +
+ 4 files changed, 92 insertions(+)
+ create mode 100644 OvmfPkg/Include/Guid/AmdSevMemEncryptLib.h
+
+diff --git a/OvmfPkg/AmdSevDxe/AmdSevDxe.c b/OvmfPkg/AmdSevDxe/AmdSevDxe.c
+index d497a343..1fa4e69a 100644
+--- a/OvmfPkg/AmdSevDxe/AmdSevDxe.c
++++ b/OvmfPkg/AmdSevDxe/AmdSevDxe.c
+@@ -15,10 +15,13 @@
+ #include <Library/BaseMemoryLib.h>
+ #include <Library/DebugLib.h>
+ #include <Library/DxeServicesTableLib.h>
++#include <Library/UefiRuntimeServicesTableLib.h>
+ #include <Library/MemEncryptSevLib.h>
+ #include <Library/MemoryAllocationLib.h>
+ #include <Library/UefiBootServicesTableLib.h>
+ #include <Guid/ConfidentialComputingSevSnpBlob.h>
++#include <Guid/AmdSevMemEncryptLib.h>
++#include <Guid/EventGroup.h>
+ #include <Library/PcdLib.h>
+ #include <Pi/PiDxeCis.h>
+ #include <Protocol/SevMemoryAcceptance.h>
+@@ -191,6 +194,39 @@ STATIC EDKII_MEMORY_ACCEPT_PROTOCOL  mMemoryAcceptProtocol = {
+   AmdSevMemoryAccept
+ };
+ 
++STATIC
++VOID
++EFIAPI
++AmdSevDxeOnEndOfDxe (
++  IN EFI_EVENT  Event,
++  IN VOID       *EventToSignal
++  )
++{
++  EFI_STATUS  Status;
++  BOOLEAN     SevLiveMigrationEnabled;
++
++  SevLiveMigrationEnabled = MemEncryptSevLiveMigrationIsEnabled ();
++
++  if (SevLiveMigrationEnabled) {
++    Status = gRT->SetVariable (
++                    L"SevLiveMigrationEnabled",
++                    &gAmdSevMemEncryptGuid,
++                    EFI_VARIABLE_NON_VOLATILE |
++                    EFI_VARIABLE_BOOTSERVICE_ACCESS |
++                    EFI_VARIABLE_RUNTIME_ACCESS,
++                    sizeof SevLiveMigrationEnabled,
++                    &SevLiveMigrationEnabled
++                    );
++
++    DEBUG ((
++      DEBUG_INFO,
++      "%a: Setting SevLiveMigrationEnabled variable, status = %lx\n",
++      __FUNCTION__,
++      Status
++      ));
++  }
++}
++
+ EFI_STATUS
+ EFIAPI
+ AmdSevDxeEntryPoint (
+@@ -203,6 +239,7 @@ AmdSevDxeEntryPoint (
+   UINTN                                     NumEntries;
+   UINTN                                     Index;
+   CONFIDENTIAL_COMPUTING_SNP_BLOB_LOCATION  *SnpBootDxeTable;
++  EFI_EVENT                                 Event;
+ 
+   //
+   // Do nothing when SEV is not enabled
+@@ -361,5 +398,35 @@ AmdSevDxeEntryPoint (
+                   );
+   }
+ 
++  //
++  // AmdSevDxe module is an apriori driver so it gets loaded between PEI
++  // and DXE phases and the SetVariable call will fail at the driver's
++  // entry point as the Variable DXE module is still not loaded yet.
++  // So we need to wait for an event notification which is signaled
++  // after the Variable DXE module is loaded, hence, using the
++  // EndOfDxe event notification to make this call.
++  //
++  // Register EFI_END_OF_DXE_EVENT_GROUP_GUID event.
++  // The notification function sets the runtime variable indicating OVMF
++  // support for SEV live migration.
++  //
++  Status = gBS->CreateEventEx (
++                  EVT_NOTIFY_SIGNAL,
++                  TPL_CALLBACK,
++                  AmdSevDxeOnEndOfDxe,
++                  NULL,
++                  &gEfiEndOfDxeEventGroupGuid,
++                  &Event
++                  );
++
++  if (EFI_ERROR (Status)) {
++    DEBUG ((
++      DEBUG_ERROR,
++      "%a: CreateEventEx(): %r\n",
++      __FUNCTION__,
++      Status
++      ));
++  }
++
+   return EFI_SUCCESS;
+ }
+diff --git a/OvmfPkg/AmdSevDxe/AmdSevDxe.inf b/OvmfPkg/AmdSevDxe/AmdSevDxe.inf
+index e7c7d526..dd1da527 100644
+--- a/OvmfPkg/AmdSevDxe/AmdSevDxe.inf
++++ b/OvmfPkg/AmdSevDxe/AmdSevDxe.inf
+@@ -57,3 +57,7 @@
+ 
+ [Pcd]
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId
++
++[Guids]
++  gAmdSevMemEncryptGuid
++  gEfiEndOfDxeEventGroupGuid         ## CONSUMES   ## Event
+diff --git a/OvmfPkg/Include/Guid/AmdSevMemEncryptLib.h b/OvmfPkg/Include/Guid/AmdSevMemEncryptLib.h
+new file mode 100644
+index 00000000..62d22e79
+--- /dev/null
++++ b/OvmfPkg/Include/Guid/AmdSevMemEncryptLib.h
+@@ -0,0 +1,20 @@
++/** @file
++
++  AMD Memory Encryption GUID, define a new GUID for defining
++  new UEFI environment variables assocaiated with SEV Memory Encryption.
++
++  Copyright (c) 2021, AMD Inc. All rights reserved.<BR>
++
++  SPDX-License-Identifier: BSD-2-Clause-Patent
++
++**/
++
++#ifndef __AMD_SEV_MEMENCRYPT_LIB_H__
++#define __AMD_SEV_MEMENCRYPT_LIB_H__
++
++#define AMD_SEV_MEMENCRYPT_GUID \
++{0x0cf29b71, 0x9e51, 0x433a, {0xa3, 0xb7, 0x81, 0xf3, 0xab, 0x16, 0xb8, 0x75}}
++
++extern EFI_GUID  gAmdSevMemEncryptGuid;
++
++#endif
+diff --git a/OvmfPkg/OvmfPkg.dec b/OvmfPkg/OvmfPkg.dec
+index e7dc7a67..199bf76d 100644
+--- a/OvmfPkg/OvmfPkg.dec
++++ b/OvmfPkg/OvmfPkg.dec
+@@ -177,6 +177,7 @@
+   gOvmfVariableGuid                     = {0x50bea1e5, 0xa2c5, 0x46e9, {0x9b, 0x3a, 0x59, 0x59, 0x65, 0x16, 0xb0, 0x0a}}
+   gQemuFirmwareResourceHobGuid          = {0x3cc47b04, 0x0d3e, 0xaa64, {0x06, 0xa6, 0x4b, 0xdc, 0x9a, 0x2c, 0x61, 0x19}}
+   gRtcRegisterBaseAddressHobGuid        = {0x40435d97, 0xeb37, 0x4a4b, {0x7f, 0xad, 0xb7, 0xed, 0x72, 0xa1, 0x43, 0xc5}}
++  gAmdSevMemEncryptGuid                 = {0x0cf29b71, 0x9e51, 0x433a, {0xa3, 0xb7, 0x81, 0xf3, 0xab, 0x16, 0xb8, 0x75}}
+ 
+ [Ppis]
+   # PPI whose presence in the PPI database signals that the TPM base address
+-- 
+2.25.1
+

--- a/debian/patches/0021-OvmfPkg-BaseMemcryptSevLib-Correct-the-calculation-o.patch
+++ b/debian/patches/0021-OvmfPkg-BaseMemcryptSevLib-Correct-the-calculation-o.patch
@@ -1,0 +1,35 @@
+From 00d3b16367bbfd393c309bd3b42d6ca680419ff2 Mon Sep 17 00:00:00 2001
+From: hanliyang <hanliyang@hygon.cn>
+Date: Mon, 17 Jan 2022 01:19:21 -0500
+Subject: [PATCH 7/9] OvmfPkg/BaseMemcryptSevLib: Correct the calculation of
+ page range that notified to hypervisor
+
+Correct the calculation of page range that notified to hypervisor.
+
+Signed-off-by: hanliyang <hanliyang@hygon.cn>
+---
+ .../Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c  | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+index c52e80ba..555218bd 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+@@ -1020,9 +1020,13 @@ SetMemoryEncDec (
+   // Notify Hypervisor on C-bit status
+   //
+   if (CBitChanged) {
++    UINTN StartPfn = OrigPhysicalAddress >> EFI_PAGE_SHIFT;
++    UINTN EndPfn = (OrigPhysicalAddress + OrigLength +
++                    ((1 << EFI_PAGE_SHIFT) - 1)) >> EFI_PAGE_SHIFT;
++
+     Status = SetMemoryEncDecHypercall3 (
+                OrigPhysicalAddress,
+-               EFI_SIZE_TO_PAGES (OrigLength),
++               (EndPfn - StartPfn),
+                (Mode == SetCBit) ? TRUE : FALSE
+                );
+   }
+-- 
+2.25.1
+

--- a/debian/patches/0022-OvmfPkg-BaseMemEncryptLib-Return-SUCCESS-if-not-supp.patch
+++ b/debian/patches/0022-OvmfPkg-BaseMemEncryptLib-Return-SUCCESS-if-not-supp.patch
@@ -1,0 +1,36 @@
+From f8dd12a5b0a32b6bdcf0d056a640cfd3a3ffcdbb Mon Sep 17 00:00:00 2001
+From: hanliyang <hanliyang@hygon.cn>
+Date: Sun, 19 Jun 2022 18:12:35 +0800
+Subject: [PATCH 8/9] OvmfPkg/BaseMemEncryptLib: Return SUCCESS if not support
+ SEV live migration
+
+Add this change to avoid trigger 'ASSERT_EFI_ERROR (Status = Unsupported)'
+when QEMU doesn't support SEV live migration.
+
+Signed-off-by: hanliyang <hanliyang@hygon.cn>
+---
+ OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c
+index a64ff2a5..7b29582d 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/MemEncryptSevLib.c
+@@ -168,10 +168,12 @@ SetMemoryEncDecHypercall3 (
+   UINTN          Error;
+   UINTN          EncryptState;
+ 
+-  Ret = RETURN_UNSUPPORTED;
++  //
++  // Return success if not support migration.
++  //
++  Ret = RETURN_SUCCESS;
+ 
+   if (MemEncryptSevLiveMigrationIsEnabled ()) {
+-    Ret = RETURN_SUCCESS;
+     //
+     // The encryption bit is set/clear on the smallest page size, hence
+     // use the 4k page size in MAP_GPA_RANGE hypercall below.
+-- 
+2.25.1
+

--- a/debian/patches/0023-OvmfPkg-BaseMemEncryptLib-Save-memory-encrypt-status.patch
+++ b/debian/patches/0023-OvmfPkg-BaseMemEncryptLib-Save-memory-encrypt-status.patch
@@ -1,0 +1,161 @@
+From b634a4e92904546b96b5159e0bf095c7fca2d3ab Mon Sep 17 00:00:00 2001
+From: Xin Jiang <jiangxin@hygon.cn>
+Date: Wed, 10 Jan 2024 17:34:57 +0800
+Subject: [PATCH 9/9] OvmfPkg/BaseMemEncryptLib: Save memory encrypt status in
+ reserved memory
+
+The MMIO routine of VC handler will get memory encrypt status to
+validate MMIO address. MemEncryptSevGetEncryptionMask() will enable
+interrupt while interrupt must be disabled during VC.
+
+During DXE stage, VC routine as below:
+CcExitHandleVc->MemEncryptSevGetAddressRangeState->
+MemEncryptSevGetEncryptionMask->PcdGet64(PcdPteMemoryEncryptionAddressOrMask)
+
+Unfortunately, PcdGet64() will enable interrupt in VC context.
+
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+---
+ OvmfPkg/AmdSev/AmdSevX64.fdf                             | 5 ++++-
+ .../Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf | 4 ++++
+ .../BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c   | 9 ++-------
+ OvmfPkg/OvmfPkg.dec                                      | 4 ++++
+ OvmfPkg/OvmfPkgX64.fdf                                   | 5 ++++-
+ OvmfPkg/PlatformPei/AmdSev.c                             | 2 ++
+ OvmfPkg/PlatformPei/Csv.c                                | 6 ++++++
+ OvmfPkg/PlatformPei/PlatformPei.inf                      | 2 ++
+ 8 files changed, 28 insertions(+), 9 deletions(-)
+
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.fdf b/OvmfPkg/AmdSev/AmdSevX64.fdf
+index 6eb9d087..24f69204 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.fdf
++++ b/OvmfPkg/AmdSev/AmdSevX64.fdf
+@@ -83,7 +83,10 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase|gUefiOvmfPkgTokenSpaceGui
+ 0x012000|0x002000
+ gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase|gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
+ 
+-0x014000|0x00C000
++0x014000|0x001000
++gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusBase|gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusSize
++
++0x015000|0x00B000
+ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
+ 
+ 0x020000|0x0E0000
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+index 2ad0c7ee..ebe13eb6 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+@@ -62,3 +62,7 @@
+ [Pcd]
+   gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask
+   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr
++
++[FixedPcd]
++  gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusBase
++  gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusSize
+diff --git a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
+index b2a68bae..e8879f10 100644
+--- a/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
++++ b/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLibInternal.c
+@@ -22,8 +22,6 @@
+ 
+ STATIC UINT64   mCurrentAttr                   = 0;
+ STATIC BOOLEAN  mCurrentAttrRead               = FALSE;
+-STATIC UINT64   mSevEncryptionMask             = 0;
+-STATIC BOOLEAN  mSevEncryptionMaskSaved        = FALSE;
+ STATIC BOOLEAN  mSevLiveMigrationStatus        = FALSE;
+ STATIC BOOLEAN  mSevLiveMigrationStatusChecked = FALSE;
+ 
+@@ -199,12 +197,9 @@ MemEncryptSevGetEncryptionMask (
+   VOID
+   )
+ {
+-  if (!mSevEncryptionMaskSaved) {
+-    mSevEncryptionMask      = PcdGet64 (PcdPteMemoryEncryptionAddressOrMask);
+-    mSevEncryptionMaskSaved = TRUE;
+-  }
++  UINT64 *MemEncryptStatus = (UINT64 *)(UINT64)FixedPcdGet32 (PcdMemEncrpytStatusBase);
+ 
+-  return mSevEncryptionMask;
++  return *MemEncryptStatus;
+ }
+ 
+ /**
+diff --git a/OvmfPkg/OvmfPkg.dec b/OvmfPkg/OvmfPkg.dec
+index 199bf76d..c8120132 100644
+--- a/OvmfPkg/OvmfPkg.dec
++++ b/OvmfPkg/OvmfPkg.dec
+@@ -363,6 +363,10 @@
+   gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase|0|UINT32|0x76
+   gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize|0|UINT32|0x77
+ 
++  ## the base address of memory encryption status.
++  gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusBase|0|UINT32|0x78
++  gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusSize|0|UINT32|0x79
++
+ [PcdsDynamic, PcdsDynamicEx]
+   gUefiOvmfPkgTokenSpaceGuid.PcdEmuVariableEvent|0|UINT64|2
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable|FALSE|BOOLEAN|0x10
+diff --git a/OvmfPkg/OvmfPkgX64.fdf b/OvmfPkg/OvmfPkgX64.fdf
+index b1702c42..04d3aded 100644
+--- a/OvmfPkg/OvmfPkgX64.fdf
++++ b/OvmfPkg/OvmfPkgX64.fdf
+@@ -103,7 +103,10 @@ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecApicPageTableBase|gUefiOvmfPkgTokenSpaceGui
+ 0x011000|0x002000
+ gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase|gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
+ 
+-0x013000|0x00D000
++0x013000|0x001000
++gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusBase|gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusSize
++
++0x014000|0x00C000
+ gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase|gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamSize
+ 
+ 0x020000|0x0E0000
+diff --git a/OvmfPkg/PlatformPei/AmdSev.c b/OvmfPkg/PlatformPei/AmdSev.c
+index 30e8a012..94dd14b5 100644
+--- a/OvmfPkg/PlatformPei/AmdSev.c
++++ b/OvmfPkg/PlatformPei/AmdSev.c
+@@ -470,6 +470,8 @@ AmdSevInitialize (
+   PcdStatus      = PcdSet64S (PcdPteMemoryEncryptionAddressOrMask, EncryptionMask);
+   ASSERT_RETURN_ERROR (PcdStatus);
+ 
++  *(UINT64 *)(UINT64)FixedPcdGet32 (PcdMemEncrpytStatusBase) = EncryptionMask;
++
+   DEBUG ((DEBUG_INFO, "SEV is enabled (mask 0x%lx)\n", EncryptionMask));
+ 
+   //
+diff --git a/OvmfPkg/PlatformPei/Csv.c b/OvmfPkg/PlatformPei/Csv.c
+index 5ab83312..71e4b9f7 100644
+--- a/OvmfPkg/PlatformPei/Csv.c
++++ b/OvmfPkg/PlatformPei/Csv.c
+@@ -33,6 +33,12 @@ CsvInitializeMemInfo (
+   UINT64                      LowerMemorySize;
+   UINT64                      UpperMemorySize;
+ 
++  BuildMemoryAllocationHob (
++    (EFI_PHYSICAL_ADDRESS)(UINTN) FixedPcdGet32 (PcdMemEncrpytStatusBase),
++    (UINT64)(UINTN) FixedPcdGet32 (PcdMemEncrpytStatusSize),
++    EfiReservedMemoryType
++    );
++
+   if (!CsvIsEnabled ()) {
+     return ;
+   }
+diff --git a/OvmfPkg/PlatformPei/PlatformPei.inf b/OvmfPkg/PlatformPei/PlatformPei.inf
+index 75a1b9e4..57a353e5 100644
+--- a/OvmfPkg/PlatformPei/PlatformPei.inf
++++ b/OvmfPkg/PlatformPei/PlatformPei.inf
+@@ -143,6 +143,8 @@
+   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSnpSecretsSize
+   gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallBase
+   gUefiOvmfPkgTokenSpaceGuid.PcdCsvDefaultSecureCallSize
++  gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusBase
++  gUefiOvmfPkgTokenSpaceGuid.PcdMemEncrpytStatusSize
+ 
+ [FeaturePcd]
+   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+-- 
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -18,3 +18,12 @@ mbedtls-disable.diff
 0012-OvmfPkg-IoMmuDxe-Add-CsvIoMmu-protocol.patch
 0013-OvmfPkg-Use-classic-mmio-window-for-CSV-guest.patch
 0014-OvmfPkg-IoMmuDxe-Implement-SetAttribute-of-CsvIoMmu.patch
+0015-OvmfPkg-BaseMemEncryptLib-Detect-SEV-live-migration-.patch
+0016-OvmfPkg-BaseMemEncryptLib-Hypercall-API-for-page-enc.patch
+0017-OvmfPkg-BaseMemEncryptLib-Invoke-page-encryption-sta.patch
+0018-OvmfPkg-VmgExitLib-Encryption-state-change-hypercall.patch
+0019-OvmfPkg-PlatformPei-Mark-SEC-GHCB-page-as-unencrypte.patch
+0020-OvmfPkg-AmdSevDxe-Add-support-for-SEV-live-migration.patch
+0021-OvmfPkg-BaseMemcryptSevLib-Correct-the-calculation-o.patch
+0022-OvmfPkg-BaseMemEncryptLib-Return-SUCCESS-if-not-supp.patch
+0023-OvmfPkg-BaseMemEncryptLib-Save-memory-encrypt-status.patch


### PR DESCRIPTION
The live migration for Hygon CSV1/2/3 guest depends on the KVM hypercall KVM_HC_MAP_GPA_RANGE, add
code to sync page enc/dec status to KVM. Then, KVM transfer these info to Qemu. During live migration, Qemu will check
whether request firmware APIs to assist migrate private pages of the guest.

In addition, OVMF will setup efi variable to express whether live migration is supported to guest's kernel. If live migration is
supported, the guest's kernel will invoke KVM_HC_MAP_GPA_RANGE to tell page enc/dec status changes when dynamic
change page enc/dec mappings.

The MMIO routine of VC handler will get memory encrypt status to validate MMIO address. MemEncryptSevGetEncryptionMask() will enable interrupt while interrupt must be disabled during VC. During DXE stage, VC routine as below:
  CcExitHandleVc
    -> MemEncryptSevGetAddressRangeState
      -> MemEncryptSevGetEncryptionMask->PcdGet64(PcdPteMemoryEncryptionAddressOrMask)

[ hly: Fix the changelog of edk2 (2024.08-2deepin1). ]

```
0015-OvmfPkg-BaseMemEncryptLib-Detect-SEV-live-migration-.patch
- Use guest's cpuid to check live migration capability of this confidential guest.
0016-OvmfPkg-BaseMemEncryptLib-Hypercall-API-for-page-enc.patch
- Introduce interface to tell page enc/dec status to KVM.
0017-OvmfPkg-BaseMemEncryptLib-Invoke-page-encryption-sta.patch
- Invoke KVM_HC_MAP_GPA_RANGE when page enc/dec status are changed.
0018-OvmfPkg-VmgExitLib-Encryption-state-change-hypercall.patch
- Support KVM_HC_MAP_GPA_RANGE for CSV2/CSV3 guest.
0019-OvmfPkg-PlatformPei-Mark-SEC-GHCB-page-as-unencrypte.patch
- Tell the page enc/dec status of the SEC Ghcb page.
0020-OvmfPkg-AmdSevDxe-Add-support-for-SEV-live-migration.patch
- Setup efi variable SevLiveMigrationEnabled so that guest's kernel will check whether live migration is supported in the guest.
0021-OvmfPkg-BaseMemcryptSevLib-Correct-the-calculation-o.patch
- Fix the number of pages when tell the enc/dec status to KVM.
0022-OvmfPkg-BaseMemEncryptLib-Return-SUCCESS-if-not-supp.patch
- Prevent ASSERT() error if live migration for confidential guest is unsupported in Qemu.
0023-OvmfPkg-BaseMemEncryptLib-Save-memory-encrypt-status.patch
- Fix nesting #VC exception caused by MMIO access.
```

## How to Test

#### Code requirements
- Linux Kernel (both host and guest use this kernel, https://github.com/deepin-community/kernel/tree/linux-6.6.y, commit 96767233880246ea3a33825d2998f21f3c8741a5);
- Qemu (https://github.com/deepin-community/qemu/tree/master + https://github.com/deepin-community/qemu/pull/22);
- Edk2 (https://github.com/deepin-community/edk2/tree/master + https://github.com/deepin-community/edk2/pull/5);

#### Generated binaries
- Linux Kernel: deb packages of the kernel, install these packages on both the host and guest, reboot the host with this new kernel.
> * Linux cmdline must contains: csv_mem_percentage=@xxx kvm-amd.sev=1 kvm-amd.sev_es=1. The @xxx is decimal number, for example, 50 means provide 50% of the total main memory for CSV3 guest at most.
> * The CPU must support CSV3 hardware feature.
> * Run command dmesg | grep 'CSV3 enabled', if we see CSV: CSV3 enabled (ASIDs ...) at the host side，it means we can launch and run CSV3 guest.
- Qemu: assume the qemu bin is installed to /usr/bin/qemu-system-x86_64
- Edk2: assuem the OVMF bin is installed to /usr/share/OVMF/OVMF_CODE_4M.fd

#### Live migrate CSV guest to target machine
> Assume the ip of the source machine is HostA_IP, the ip of the target machine is HostB_IP.
- Act on target machine: Get cert chain at target machine
```
$ sudo ./hag csv export_cert_chain
$cat hsk.cert hrk.cert > vendor_cert.bin
$cat pek.cert oca.cert cek.cert > plat_cert.bin
$cat pdh.cert > pdh.bin
$base64 -w 0 vendor_cert.bin > vendor_cert.base64
$base64 -w 0 plat_cert.bin > plat_cert.base64
$base64 -w 0 pdh.bin > pdh.base64
$sudo chmod 666 *.base64
$cp -a *.base64 /tmp
```
- Act on source machine: Transfer target machine's cert chain to source machine
```
$ scp ${HostB_IP}:/tmp/*.base64 /tmp/
```
- Act on target machine: Create CSV guest on target machine
```
$ /usr/bin/qemu-system-x86_64 \
-name csv-receive --enable-kvm -cpu host -m 6G -smp 40 \
-drive if=pflash,format=raw,unit=0,file=/usr/share/OVMF/OVMF_CODE_4M.fd,readonly=on \
-object sev-guest,id=sev0,policy=0x1,cbitpos=47,reduced-phys-bits=5 \
-machine memory-encryption=sev0 \
-device virtio-blk-pci,scsi=off,drive=drive0,disable-legacy=on,iommu_platform=on,bootindex=1 \
-drive file=csv_receive.qcow2,format=qcow2,if=none,id=drive0 \
-vnc 0.0.0.0:1 -qmp tcp:localhost:4445,server,nowait \
-incoming tcp:${HostB_IP}:6666 &
```
- Act on source machine: Create CSV guest on source machine
```
$ /usr/bin/qemu-system-x86_64 \
-name csv-send --enable-kvm -cpu host -m 6G -smp 40 \
-drive if=pflash,format=raw,unit=0,file=/usr/share/OVMF/OVMF_CODE_4M.fd,readonly=on \
-object sev-guest,id=sev0,policy=0x1,cbitpos=47,reduced-phys-bits=5 \
-machine memory-encryption=sev0 \
-device virtio-blk-pci,scsi=off,drive=drive0,disable-legacy=on,iommu_platform=on,bootindex=1 \
-drive file=csv_send.qcow2,format=qcow2,if=none,id=drive0 \
-vnc 0.0.0.0:0 -qmp tcp:localhost:4444,server,nowait &
```
- Act on source machine: Issue live migration on source machine
```
$ sudo socat - tcp:${HostA_IP}:4444
{"QMP": {"version": {"qemu": {"micro": 0, "minor": 2, "major": 8}, "package": "Debian 1:8.2.0+ds-1deepin5"}, "capabilities": ["oob"]}}
{"execute":"qmp_capabilities"}
{"return": {}}
{"execute":"migrate-set-parameters","arguments":{"sev-pdh":"/tmp/pdh.base64","sev-plat-cert":"/tmp/plat_cert.base64","sev-amd-cert":"/tmp/vendor_cert.base64"}}
{"return": {}}
{"execute":"migrate","arguments":{"uri":"${HostB_IP}:6666"}}
{"return": {}}
```
- Wait a while, the guest on source machine will be stopped, and the guest on the target machine continues to run based on the state of guest on source machine.

> The process to live migrate CSV2/CSV3 guest are the same as CSV guest. For CSV2 guest, the bit2 (start from bit 0) of the policy attr must be set; For CSV3 guest, the bit2 and bit6 (start from bit 0) of the policy attr must be set.