### PR TITLE
Generate OVMF.CSV.fd in build target @build-ovmf@

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+edk2 (2024.08-2deepin4) unstable; urgency=medium
+
+  * Generate OVMF.CSV.fd in build target build-ovmf:
+    - d/p/0025-Change-grub.sh-to-generate-OVMF.CSV.fd-in-build-ovmf.patch
+
+ -- hanliyang <hanliyang@hygon.cn>  Tue, 24 Dec 2024 19:50:28 +0800
+
 edk2 (2024.08-2deepin3) unstable; urgency=medium
 
   * Support full-disk encryption for Hygon CSV/CSV2/CSV3 guest:

--- a/debian/ovmf.install
+++ b/debian/ovmf.install
@@ -1,4 +1,5 @@
 debian/ovmf-install/OVMF.fd		/usr/share/ovmf
+debian/ovmf-install/OVMF.CSV.fd		/usr/share/ovmf
 debian/ovmf-install/OVMF_CODE*.fd	/usr/share/OVMF
 debian/ovmf-install/OVMF_VARS*.fd	/usr/share/OVMF
 debian/descriptors/*-edk2-x86_64*.json	/usr/share/qemu/firmware

--- a/debian/patches/0025-Change-grub.sh-to-generate-OVMF.CSV.fd-in-build-ovmf.patch
+++ b/debian/patches/0025-Change-grub.sh-to-generate-OVMF.CSV.fd-in-build-ovmf.patch
@@ -1,0 +1,25 @@
+From b440c4e43a8089a4ac1f06f807df7c295cc81d5a Mon Sep 17 00:00:00 2001
+From: hanliyang <hanliyang@hygon.cn>
+Date: Tue, 24 Dec 2024 06:32:55 +0000
+Subject: [PATCH] Change grub.sh to generate OVMF.CSV.fd in @build-ovmf@
+
+Signed-off-by: hanliyang <hanliyang@hygon.cn>
+---
+ OvmfPkg/AmdSev/Grub/grub.sh | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/OvmfPkg/AmdSev/Grub/grub.sh b/OvmfPkg/AmdSev/Grub/grub.sh
+index c8e57a18..760a03b8 100644
+--- a/OvmfPkg/AmdSev/Grub/grub.sh
++++ b/OvmfPkg/AmdSev/Grub/grub.sh
+@@ -84,7 +84,6 @@ mcopy -i "${basedir}/disk.fat" -- "${basedir}/grub.cfg" ::grub.cfg
+ ${mkimage} -O x86_64-efi \
+            -p '(crypto0)' \
+            -c "${basedir}/grub-bootstrap.cfg" \
+-           -d "/opt/grub/lib/grub/x86_64-efi" \
+            -m "${basedir}/disk.fat" \
+            -o "${basedir}/grub.efi" \
+            ${GRUB_MODULES}
+-- 
+2.45.2
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -28,3 +28,4 @@ mbedtls-disable.diff
 0022-OvmfPkg-BaseMemEncryptLib-Return-SUCCESS-if-not-supp.patch
 0023-OvmfPkg-BaseMemEncryptLib-Save-memory-encrypt-status.patch
 0024-OvmfPkg-AmdSev-Support-full-disk-encryption-based-on.patch
+0025-Change-grub.sh-to-generate-OVMF.CSV.fd-in-build-ovmf.patch

--- a/debian/rules
+++ b/debian/rules
@@ -75,8 +75,7 @@ OVMF64_BUILD_DIR_CSV = $(OVMF64_BUILD_ROOT_CSV)/$(BUILD_TYPE)_$(EDK2_TOOLCHAIN)
 OVMF_ENROLL = $(OVMF_INSTALL_DIR)/EnrollDefaultKeys.efi
 OVMF_SHELL =  $(OVMF_INSTALL_DIR)/Shell.efi
 OVMF_BINARIES = $(OVMF_ENROLL) $(OVMF_SHELL)
-OVMF_IMAGES := $(addprefix $(OVMF_INSTALL_DIR)/,OVMF_CODE_4M.fd OVMF_CODE_4M.secboot.fd OVMF_VARS_4M.fd)
-OVMF_IMAGES_CSV := $(addprefix $(OVMF_INSTALL_DIR)/,OVMF.CSV.fd)
+OVMF_IMAGES := $(addprefix $(OVMF_INSTALL_DIR)/,OVMF_CODE_4M.fd OVMF_CODE_4M.secboot.fd OVMF_VARS_4M.fd OVMF.CSV.fd)
 OVMF_PREENROLLED_VARS := $(addprefix $(OVMF_INSTALL_DIR)/,OVMF_VARS_4M.ms.fd OVMF_VARS_4M.snakeoil.fd)
 
 OVMF32_INSTALL_DIR = debian/ovmf32-install
@@ -156,9 +155,7 @@ $(OVMF_BINARIES) $(OVMF_IMAGES): debian/setup-build-stamp
 		$(OVMF_INSTALL_DIR)/
 	cp $(OVMF64_BUILD_DIR)/FV/OVMF_CODE.fd \
 		$(OVMF_INSTALL_DIR)/OVMF_CODE_4M.secboot.fd
-
-build-ovmf-csv: build-ovmf $(OVMF_IMAGES_CSV)
-$(OVMF_IMAGES_CSV): debian/setup-build-stamp
+	rm -rf $(OVMF64_BUILD_ROOT_CSV)
 	rm -f OvmfPkg/AmdSev/Grub/grub.efi
 	set -e; . ./edksetup.sh; \
 		build -a X64 \
@@ -335,4 +332,4 @@ get-orig-source:
 		edk2-$(DEB_VERSION_UPSTREAM)
 	rm -rf edk2.tmp edk2-$(DEB_VERSION_UPSTREAM)
 
-.PHONY: build-ovmf build-ovmf32 build-qemu-efi build-qemu-efi-aarch64 build-qemu-efi-arm build-qemu-efi-riscv64 build-ovmf-csv
+.PHONY: build-ovmf build-ovmf32 build-qemu-efi build-qemu-efi-aarch64 build-qemu-efi-arm build-qemu-efi-riscv64


### PR DESCRIPTION
The OVMF.CSV.fd will be installed to /usr/share/ovmf/OVMF.CSV.fd.    [used for `kernel hashes` and `full-disk encryption`]