### PR TITLE
fix: skip OVMF/OVMF32 build on non-x86 hosts to fix loongarch64 build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,8 +11,14 @@ edk2 (2024.08-2deepin6) unstable; urgency=medium
       LoongArch gcc and failed with:
         gcc: error: unrecognized argument in option '-march=x86-64'
         error F002: Failed to build module
-    - Gate build-ovmf/build-ovmf32 on DEB_BUILD_ARCH=amd64 so OVMF/OVMF32
+    - Gate build-ovmf/build-ovmf32 on x86 hosts (amd64: build-ovmf +
+      build-ovmf32; i386: build-ovmf32; else: neither) so OVMF/OVMF32
       firmwares continue to be produced on x86 build hosts
+    - Gate the x86-only package install lists (ovmf, ovmf-ia32,
+      efi-shell-x64, efi-shell-ia32) to the x86 architectures via dh-exec
+      [amd64]/[amd64 i386] filters, so dh_install does not fail on non-x86
+      hosts where the OVMF outputs do not exist; binary packages stay
+      Architecture: all
     - qemu-efi-loongarch64, qemu-efi-riscv64, qemu-efi-aarch64 and qemu-efi-arm
       are still built on all architectures
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+edk2 (2024.08-2deepin6) unstable; urgency=medium
+
+  * Fix edk2 binary package build on loongarch64
+    - Skip build-ovmf and build-ovmf32 on non-x86 build hosts (arm64,
+      loongarch64, riscv64, ...)
+    - OVMF (X64) and OVMF32 (IA32) use native x86 compiler options
+      (-m64/-m32, -march=x86-64, -mcmodel=small, -maccumulate-outgoing-args,
+      -mno-red-zone, -mno-mmx, -mno-sse) that are not supported by non-x86
+      compilers
+    - On loong64 the OVMF X64 build previously fell back to the native
+      LoongArch gcc and failed with:
+        gcc: error: unrecognized argument in option '-march=x86-64'
+        error F002: Failed to build module
+    - Gate build-ovmf/build-ovmf32 on DEB_BUILD_ARCH=amd64 so OVMF/OVMF32
+      firmwares continue to be produced on x86 build hosts
+    - qemu-efi-loongarch64, qemu-efi-riscv64, qemu-efi-aarch64 and qemu-efi-arm
+      are still built on all architectures
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 25 Aug 2026 11:08:00 +0800
+
 edk2 (2024.08-2deepin5) unstable; urgency=medium
 
   * Add loongarch64 support:

--- a/debian/efi-shell-ia32.install
+++ b/debian/efi-shell-ia32.install
@@ -1,2 +1,2 @@
 #!/usr/bin/dh-exec
-debian/ovmf32-install/Shell.efi => /usr/share/efi-shell-ia32/shellia32.efi
+[amd64 i386] debian/ovmf32-install/Shell.efi => /usr/share/efi-shell-ia32/shellia32.efi

--- a/debian/efi-shell-x64.install
+++ b/debian/efi-shell-x64.install
@@ -1,2 +1,2 @@
 #!/usr/bin/dh-exec
-debian/ovmf-install/Shell.efi => /usr/share/efi-shell-x64/shellx64.efi
+[amd64] debian/ovmf-install/Shell.efi => /usr/share/efi-shell-x64/shellx64.efi

--- a/debian/ovmf-ia32.install
+++ b/debian/ovmf-ia32.install
@@ -1,4 +1,5 @@
-debian/ovmf32-install/OVMF32_CODE*.fd		/usr/share/OVMF
-debian/ovmf32-install/OVMF32_VARS*.fd		/usr/share/OVMF
-debian/descriptors/50-edk2-i386-secure.json	/usr/share/qemu/firmware
-debian/descriptors/60-edk2-i386.json		/usr/share/qemu/firmware
+#!/usr/bin/dh-exec
+[amd64 i386] debian/ovmf32-install/OVMF32_CODE*.fd		/usr/share/OVMF
+[amd64 i386] debian/ovmf32-install/OVMF32_VARS*.fd		/usr/share/OVMF
+[amd64 i386] debian/descriptors/50-edk2-i386-secure.json	/usr/share/qemu/firmware
+[amd64 i386] debian/descriptors/60-edk2-i386.json		/usr/share/qemu/firmware

--- a/debian/ovmf.install
+++ b/debian/ovmf.install
@@ -1,6 +1,7 @@
-debian/ovmf-install/OVMF.fd		/usr/share/ovmf
-debian/ovmf-install/OVMF.CSV.fd		/usr/share/ovmf
-debian/ovmf-install/OVMF_CODE*.fd	/usr/share/OVMF
-debian/ovmf-install/OVMF_VARS*.fd	/usr/share/OVMF
-debian/descriptors/*-edk2-x86_64*.json	/usr/share/qemu/firmware
-debian/PkKek-1-snakeoil.*			/usr/share/ovmf
+#!/usr/bin/dh-exec
+[amd64] debian/ovmf-install/OVMF.fd		/usr/share/ovmf
+[amd64] debian/ovmf-install/OVMF.CSV.fd		/usr/share/ovmf
+[amd64] debian/ovmf-install/OVMF_CODE*.fd	/usr/share/OVMF
+[amd64] debian/ovmf-install/OVMF_VARS*.fd	/usr/share/OVMF
+[amd64] debian/descriptors/*-edk2-x86_64*.json	/usr/share/qemu/firmware
+[amd64] debian/PkKek-1-snakeoil.*			/usr/share/ovmf

--- a/debian/rules
+++ b/debian/rules
@@ -65,7 +65,28 @@ undefine CONF_PATH
 %:
 	dh $@
 
-override_dh_auto_build: build-qemu-efi-aarch64 build-qemu-efi-arm build-ovmf build-ovmf32 build-qemu-efi-loongarch64 build-qemu-efi-riscv64
+# The OVMF (X64) and OVMF32 (IA32) firmwares are built with native x86
+# compiler options (-m64/-m32, -march=x86-64, -mcmodel=small,
+# -maccumulate-outgoing-args, -mno-red-zone, -mno-mmx, -mno-sse, ...)
+# that are not supported by compilers for other architectures. They can
+# therefore only be produced on x86 build hosts (amd64/i386), where the
+# native gcc is already an x86 compiler. On every other build host
+# (arm64, loongarch64, riscv64, ...) GCC5 has no *_X64/_IA32_PREFIX set,
+# so the OVMF build falls back to the native host gcc (e.g. LoongArch gcc
+# on loong64) and fails with "unrecognized argument in option
+# '-march=x86-64'". Skip build-ovmf/build-ovmf32 unless building on an
+# x86 architecture. The ovmf, ovmf-ia32, efi-shell-x64 and efi-shell-ia32
+# binary packages are still produced on the x86 architectures where the
+# corresponding virtual machines run.
+ifeq ($(DEB_BUILD_ARCH),amd64)
+	OVMF_BUILD_TARGETS = build-ovmf build-ovmf32
+else ifeq ($(DEB_BUILD_ARCH),i386)
+	OVMF_BUILD_TARGETS = build-ovmf32
+else
+	OVMF_BUILD_TARGETS =
+endif
+
+override_dh_auto_build: build-qemu-efi-aarch64 build-qemu-efi-arm $(OVMF_BUILD_TARGETS) build-qemu-efi-loongarch64 build-qemu-efi-riscv64
 
 debian/setup-build-stamp:
 	set -e; . ./edksetup.sh; \

--- a/debian/rules
+++ b/debian/rules
@@ -79,11 +79,11 @@ undefine CONF_PATH
 # binary packages are still produced on the x86 architectures where the
 # corresponding virtual machines run.
 ifeq ($(DEB_BUILD_ARCH),amd64)
-	OVMF_BUILD_TARGETS = build-ovmf build-ovmf32
+OVMF_BUILD_TARGETS = build-ovmf build-ovmf32
 else ifeq ($(DEB_BUILD_ARCH),i386)
-	OVMF_BUILD_TARGETS = build-ovmf32
+OVMF_BUILD_TARGETS = build-ovmf32
 else
-	OVMF_BUILD_TARGETS =
+OVMF_BUILD_TARGETS =
 endif
 
 override_dh_auto_build: build-qemu-efi-aarch64 build-qemu-efi-arm $(OVMF_BUILD_TARGETS) build-qemu-efi-loongarch64 build-qemu-efi-riscv64


### PR DESCRIPTION
## 背景 / Background

在 loongarch64 构建机上执行 `dpkg-buildpackage` 构建 edk2 (2024.08-2deepin5) 时失败。

构建日志关键错误：

```
build -a X64 -t GCC5 -p OvmfPkg/OvmfPkgX64.dsc ...
"gcc" ... -m64 -march=x86-64 -mcmodel=small -maccumulate-outgoing-args -mno-red-zone -mno-mmx -mno-sse ...
gcc: error: unrecognized argument in option '-march=x86-64'
: error F002: Failed to build module
make[1]: *** [debian/rules:147：debian/ovmf-install/EnrollDefaultKeys.efi] 错误 1
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```

原因：`debian/rules` 的 `override_dh_auto_build` 无条件执行 `build-ovmf`（X64）与 `build-ovmf32`（IA32）。这两个固件使用原生 x86 编译器选项（`-m64/-m32`、`-march=x86-64`、`-mcmodel=small`、`-mno-mmx`、`-mno-sse` 等）。GCC5 的 `*_X64/_IA32_PREFIX` 未设置，非 x86 主机会回退到本机编译器（loong64 上即龙芯 gcc），无法识别 x86 选项而失败。

## 修复 / Fix

按 `DEB_BUILD_ARCH` 门控 OVMF/OVMF32 构建目标：

- amd64：`build-ovmf` + `build-ovmf32`（与之前一致）
- i386：`build-ovmf32`
- 其它（arm64、loongarch64、riscv64 …）：均跳过

qemu-efi-aarch64 / qemu-efi-arm / qemu-efi-loongarch64 / qemu-efi-riscv64 仍在所有架构上构建，因此 ovmf、ovmf-ia32、efi-shell-x64、efi-shell-ia32 二进制包继续在相应 x86 架构上生成。

## 变更 / Changes

- `debian/rules`：新增 `OVMF_BUILD_TARGETS` 架构门控
- `debian/changelog`：2024.08-2deepin6

## 验证 / Verification

- `make -f debian/rules` 语法检查通过
- amd64: `OVMF_BUILD_TARGETS = build-ovmf build-ovmf32`
- i386: `OVMF_BUILD_TARGETS = build-ovmf32`
- loongarch64/arm64: `OVMF_BUILD_TARGETS =`（空，跳过 OVMF）